### PR TITLE
Rename Console to Dashboard

### DIFF
--- a/v1.0-mintlify/define-integrations/destinations.mdx
+++ b/v1.0-mintlify/define-integrations/destinations.mdx
@@ -4,15 +4,15 @@ title: "Destinations"
 
 We currently support webhooks as destinations for read actions and subscribe actions. When we get new data, we will send a message to your webhook. See [Example webhook message](doc:read-actions#example-webhook-message) for what the payload will look like.
 
-# Add a destination to the Ampersand Console
+# Add a destination to the Ampersand Dashboard
 
-Go to the [Destinations page](https://console.withampersand.com/projects/_/destinations/new) of Ampersand Console to add a new Destination. You'll need:
+Go to the [Destinations page](https://dashboard.withampersand.com/projects/_/destinations/new) of Ampersand Dashboard to add a new Destination. You'll need:
 * **Destination name**: this is an alias for the webhook that you can then refer to in the `amp.yaml` file.
 * **URL**: this is the URL of your webhook, it must start with `https`. If you do not have a webhook already, you can easily create a temporary one using tools like [Hookdeck Console](https://console.hookdeck.com). 
 
 # Refer to the destination in your integration
 
-For read and subscribe actions, you can specify destinations for each object. You can either have one destination for each object or route multiple objects to the same destination. Here's what your `amp.yaml` file might look like if you had created 2 destinations in the Ampersand Console, one named `accountWebhook` and one named `contactWebhook`.
+For read and subscribe actions, you can specify destinations for each object. You can either have one destination for each object or route multiple objects to the same destination. Here's what your `amp.yaml` file might look like if you had created 2 destinations in the Ampersand Dashboard, one named `accountWebhook` and one named `contactWebhook`.
 
 
 ```YAML YAML

--- a/v1.0-mintlify/define-integrations/proxy-actions.mdx
+++ b/v1.0-mintlify/define-integrations/proxy-actions.mdx
@@ -18,8 +18,8 @@ All proxy actions expose an API with the base of `https://proxy.withampersand.co
 Keep the request body and HTTP verb the same, and add these additional headers so Ampersand knows how to deliver the API request:
 
 * `x-amp-proxy-version`: this should always be 1
-* `x-amp-project-id`: your Ampersand project ID. You can find it on your project's [General Settings page](https://console.withampersand.com/projects/_/settings)
-* `x-api-key`: your Ampersand API key, if you don't have one yet, create one in the Ampersand Console.
+* `x-amp-project-id`: your Ampersand project ID. You can find it on your project's [General Settings page](https://dashboard.withampersand.com/projects/_/settings)
+* `x-api-key`: your Ampersand API key, if you don't have one yet, create one in the Ampersand Dashboard.
 
 In order for Ampersand to know which SaaS instance to make the API call against, you'll need to provide either:
 

--- a/v1.0-mintlify/embeddable-ui-components.mdx
+++ b/v1.0-mintlify/embeddable-ui-components.mdx
@@ -24,8 +24,8 @@ yarn add @amp-labs/react @chakra-ui/react @emotion/react @emotion/styled framer-
 
 This library requires your components to be wrapped in the `<AmpersandProvider/>` context. `<AmpersandProvider />` takes these props:
 
-* `apiKey`: an API key to access Ampersand services. If you don't have one yet, create one on the [API keys page](https://console.withampersand.com/projects/_/api-keys) of Ampersand Console.
-* `projectId`: your Ampersand project ID. You can find it on your project's [General Settings page](https://console.withampersand.com/projects/_/settings).
+* `apiKey`: an API key to access Ampersand services. If you don't have one yet, create one on the [API keys page](https://dashboard.withampersand.com/projects/_/api-keys) of Ampersand Dashboard.
+* `projectId`: your Ampersand project ID. You can find it on your project's [General Settings page](https://dashboard.withampersand.com/projects/_/settings).
 
 ### Example
 

--- a/v1.0-mintlify/generate-mint.ts
+++ b/v1.0-mintlify/generate-mint.ts
@@ -66,12 +66,12 @@ const mintConfig: MintConfig = {
 
   topbarCtaButton: {
     name: "Start building now",
-    url: "https://console.withampersand.com/sign-up",
+    url: "https://dashboard.withampersand.com/sign-up",
   },
   topbarLinks: [
     {
       name: "Sign in",
-      url: "https://console.withampersand.com/sign-in",
+      url: "https://dashboard.withampersand.com/sign-in",
     },
   ],
   anchors: [

--- a/v1.0-mintlify/mint.json
+++ b/v1.0-mintlify/mint.json
@@ -13,12 +13,12 @@
   "theme": "quill",
   "topbarCtaButton": {
     "name": "Start building now",
-    "url": "https://console.withampersand.com/sign-up"
+    "url": "https://dashboard.withampersand.com/sign-up"
   },
   "topbarLinks": [
     {
       "name": "Sign in",
-      "url": "https://console.withampersand.com/sign-in"
+      "url": "https://dashboard.withampersand.com/sign-in"
     }
   ],
   "anchors": [


### PR DESCRIPTION
Rename console to dashboard in all guides except provider guides - those will be a follow up.