### PR TITLE
[ENG-1701] feat: update generate-mint script to get around collisions

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     },
     "devDependencies": {
         "@mintlify/scraping": "*",
+        "gray-matter": "^4.0.3",
         "@types/node": "^20.14.10",
         "axios": "^1.7.3",
         "fs": "0.0.1-security",


### PR DESCRIPTION
What this does is look for an `openApiSource` for each navigation group, and adds the source as a prefix (https://mintlify.com/docs/api-playground/openapi/setup#manually-specify-files) by modifying the content of each file in that navigation group. With this, each API reference file will only look for the method in the specified source spec.

From code comments - 
> // This is helpful to avoid collisions when we have similar paths across different endpoints / specs. For example, the `read` and `write` specs have the same POST path for on-demand read & write. 

Unfortunately, the `mintlify-scraper` does not automatically have an option to do so.

### Before
A file could look like (after running `pnpm run gen`)
```
---
openapi: post /projects/{projectIdOrName}/integrations/{integrationId}/revisions
---
```

### After
Now it looks like -
```
---
openapi: 'api post /projects/{projectIdOrName}/integrations/{integrationId}/revisions'
---
```

The `api` part specifies that it should find the method only in `api.json` spec.

## Testing
Where a method was the same between two different specs (`read` on demand & `write`), this was happening (note the title of the read request is the same as the write method) -
<img width="1255" alt="Screenshot 2024-12-02 at 6 26 16 PM" src="https://github.com/user-attachments/assets/24965ffc-db62-425c-85cf-0cc39a8c3779">

Now - 
<img width="1142" alt="Screenshot 2024-12-02 at 6 27 03 PM" src="https://github.com/user-attachments/assets/aa7324c0-4ac5-49ff-b4a7-12f1849d6a0e">
