### PR TITLE
[CON-698] Klaviyo add more supported objects

### DIFF
--- a/src/provider-guides/klaviyo.mdx
+++ b/src/provider-guides/klaviyo.mdx
@@ -11,9 +11,58 @@ This connector supports:
 - [Proxy Actions](/define-integrations/proxy-actions), using the base URL `https://a.klaviyo.com`.
 
 The Klaviyo connector supports writing to and reading from the following objects:
+- [catalog-categories](https://developers.klaviyo.com/en/reference/get_catalog_categories)
+- [catalog-items](https://developers.klaviyo.com/en/reference/get_catalog_items)
+- [catalog-variants](https://developers.klaviyo.com/en/reference/get_catalog_variants)
+- [images](https://developers.klaviyo.com/en/reference/get_images)
 - [lists](https://developers.klaviyo.com/en/reference/get_lists)
 - [profiles](https://developers.klaviyo.com/en/reference/get_profiles)
 - [segments](https://developers.klaviyo.com/en/reference/get_segments)
+- [template-universal-content](https://developers.klaviyo.com/en/reference/get_all_universal_content)
+- [templates](https://developers.klaviyo.com/en/reference/get_templates)
+- [webhooks](https://developers.klaviyo.com/en/reference/get_webhooks)
+
+Objects with partial support are as follows:
+- [accounts](https://developers.klaviyo.com/en/reference/get_accounts) (read backfill only; no write)
+- [catalog-category-bulk-create-jobs](https://developers.klaviyo.com/en/reference/get_create_categories_jobs) (read/create)
+- [catalog-category-bulk-delete-jobs](https://developers.klaviyo.com/en/reference/get_delete_categories_jobs) (read/create)
+- [catalog-category-bulk-update-jobs](https://developers.klaviyo.com/en/reference/get_update_categories_jobs) (read/create)
+- [catalog-item-bulk-create-jobs](https://developers.klaviyo.com/en/reference/get_bulk_create_catalog_items_jobs) (read/create)
+- [catalog-item-bulk-delete-jobs](https://developers.klaviyo.com/en/reference/get_bulk_delete_catalog_items_jobs) (read/create)
+- [catalog-item-bulk-update-jobs](https://developers.klaviyo.com/en/reference/get_bulk_update_catalog_items_jobs) (read/create)
+- [catalog-variant-bulk-create-jobs](https://developers.klaviyo.com/en/reference/get_create_variants_jobs) (read/create)
+- [catalog-variant-bulk-delete-jobs](https://developers.klaviyo.com/en/reference/get_delete_variants_jobs) (read/create)
+- [catalog-variant-bulk-update-jobs](https://developers.klaviyo.com/en/reference/get_update_variants_jobs) (read/create)
+- [coupon-code-bulk-create-jobs](https://developers.klaviyo.com/en/reference/get_bulk_create_coupon_code_jobs) (read/create)
+- [coupons](https://developers.klaviyo.com/en/reference/get_coupons) (read backfill only, write)
+- [events](https://developers.klaviyo.com/en/reference/get_events) (read/create)
+- [flows](https://developers.klaviyo.com/en/reference/get_flows) (read/update)
+- [metrics](https://developers.klaviyo.com/en/reference/get_metrics) (read)
+- [profile-bulk-import-jobs](https://developers.klaviyo.com/en/reference/get_bulk_import_profiles_jobs) (read/create)
+- [profile-suppression-bulk-create-jobs](https://developers.klaviyo.com/en/reference/get_bulk_suppress_profiles_jobs) (read/create)
+- [profile-suppression-bulk-delete-jobs](https://developers.klaviyo.com/en/reference/get_bulk_unsuppress_profiles_jobs) (read/create)
+- [tag-groups](https://developers.klaviyo.com/en/reference/get_tag_groups) (read backfill only; write)
+- [tags](https://developers.klaviyo.com/en/reference/get_tags) (read backfill only; write)
+
+Objects without read but with write only are as follows:
+- [back-in-stock-subscriptions](https://developers.klaviyo.com/en/reference/create_back_in_stock_subscription) (create)
+- [campaign-message-assign-template](https://developers.klaviyo.com/en/reference/assign_template_to_campaign_message) (create)
+- [campaign-messages](https://developers.klaviyo.com/en/reference/update_campaign_message) (update)
+- [campaign-send-jobs](https://developers.klaviyo.com/en/reference/send_campaign) (write)
+- [client-back-in-stock-subscriptions](https://developers.klaviyo.com/en/reference/create_client_back_in_stock_subscription) (create)
+- [client-event-bulk-create](https://developers.klaviyo.com/en/reference/bulk_create_client_events) (create)
+- [client-events](https://developers.klaviyo.com/en/reference/bulk_create_client_events) (create)
+- [client-profiles](https://developers.klaviyo.com/en/reference/create_client_profile) (create)
+- [client-push-token-unregister](https://developers.klaviyo.com/en/reference/unregister_client_push_token) (create)
+- [client-push-tokens](https://developers.klaviyo.com/en/reference/create_client_push_token) (create)
+- [client-subscriptions](https://developers.klaviyo.com/en/reference/create_client_subscription) (create)
+- [data-privacy-deletion-jobs](https://developers.klaviyo.com/en/reference/request_profile_deletion) (create)
+- [event-bulk-create-jobs](https://developers.klaviyo.com/en/reference/bulk_create_events) (create)
+- [image-upload](https://developers.klaviyo.com/en/reference/upload_image_from_file) (create)
+- [metric-aggregates](https://developers.klaviyo.com/en/reference/query_metric_aggregates) (create)
+- [profile-subscription-bulk-create-jobs](https://developers.klaviyo.com/en/reference/bulk_subscribe_profiles) (create)
+- [profile-subscription-bulk-delete-jobs](https://developers.klaviyo.com/en/reference/bulk_unsubscribe_profiles) (create)
+- [push-tokens](https://developers.klaviyo.com/en/reference/create_push_token) (create)
 
 Please reach out to us if there are more objects that you need support for.
 


### PR DESCRIPTION
Added more objects that Klaviyo supports. For all read made API calls, empty response counted as success, also double checked with documentation. There were some objects that failed this check and are not included.

There are many exclusive write operations that are exposed via connector and should work, added them as dedicated section.

Updated slab docs describing exceptions.