### PR TITLE
Revert "[CON-703] feat: Add Documentation for ZohoCRM supported objects"

### DIFF
--- a/src/provider-guides/zoho.mdx
+++ b/src/provider-guides/zoho.mdx
@@ -1,47 +1,12 @@
 ---
 title: "Zoho"
 ---
-
 ## What's Supported
 
 ### Supported Actions
 
 This connector supports:
-
-- [Read Actions](/define-integrations/read-actions), including full historic backfill and incremental read.
-- [Write Actions](/define-integrations/write-actions).
 - [Proxy Actions](/define-integrations/proxy-actions), using the base URL `https://www.zohoapis.com`.
-
-### Supported Objects
-
-The ZohoCRM connector allows you to read from and write to these objects:
-
-- [Leads](https://www.zoho.com/crm/developer/docs/api/v6/get-records.html)
-- Accounts
-- Contacts
-- Deals
-- Campaigns
-- Tasks
-- Cases
-- Events
-- Calls
-- Solutions
-- Products
-- Vendors
-- Price
-- Books
-- Quotes
-- Sales Orders
-- Purchase Orders
-- Invoices
-- Appointments
-- Appointments Rescheduled History
-- Services
-- Custom
-
-### Example integration
-
-For an example manifest file of a CloseCRM integration, visit our [samples repo on Github](https://github.com/amp-labs/samples/blob/main/closecrm/amp.yaml).
 
 ## Before You Get Started
 
@@ -77,6 +42,7 @@ Follow the steps below to create a _Zoho_ app and add the Ampersand redirect URL
 You'll see the details of your newly created application. Note the **Client ID** and **Client Secret** keys as they are necessary for connecting your app to Ampersand.
 
 ![Alt text](/images/provider-guides/8dcf7de-zohocrm1.gif)
+
 
 ## Add Your Zoho App Info to Ampersand
 


### PR DESCRIPTION
Reverts amp-labs/docs#124

Reverted because deep connector has not been released.