### PR TITLE
[CON-1635] feat: Update Marketo Object Links

### DIFF
--- a/src/provider-guides/marketo.mdx
+++ b/src/provider-guides/marketo.mdx
@@ -13,18 +13,21 @@ This connector supports:
 ### Supported Objects
 The Marketo connector supports reading from the following objects:
 
-- [Campaigns](https://developer.adobe.com/marketo-apis/api/mapi/#tag/Campaigns)
-- [Custom Objects](https://developer.adobe.com/marketo-apis/api/mapi/#tag/Custom-Objects)
-- [Lists](https://developer.adobe.com/marketo-apis/api/mapi/#tag/Static-Lists)
+- [Campaigns](https://developer.adobe.com/marketo-apis/api/mapi/#operation/getCampaignsUsingGET)
+- [Companies](https://developer.adobe.com/marketo-apis/api/mapi/#operation/getCompaniesUsingGET)
+- [Custom Objects](https://developer.adobe.com/marketo-apis/api/mapi/#operation/listCustomObjectsUsingGET)
+- [Leads](https://developer.adobe.com/marketo-apis/api/mapi/#operation/getLeadsByFilterUsingGET)
+- [Lists](https://developer.adobe.com/marketo-apis/api/mapi/#operation/getListsUsingGET)
+- [SalesPersons](https://developer.adobe.com/marketo-apis/api/mapi/#operation/getSalesPersonUsingGET)
 
 The Marketo connector supports writing to the following objects:
 
-- [Companies](https://developer.adobe.com/marketo-apis/api/mapi/#tag/Companies)
-- [Leads](https://developer.adobe.com/marketo-apis/api/mapi/#tag/Leads)
-- [Named Account Lists](https://developer.adobe.com/marketo-apis/api/mapi/#tag/Named-Account-Lists)
-- [Named Accounts](https://developer.adobe.com/marketo-apis/api/mapi/#tag/Named-Accounts)
-- [Opportunities](https://developer.adobe.com/marketo-apis/api/mapi/#tag/Opportunities)
-- [Sales Persons](https://developer.adobe.com/marketo-apis/api/mapi/#tag/Sales-Persons)
+- [Companies](https://developer.adobe.com/marketo-apis/api/mapi/#operation/syncCompaniesUsingPOST)
+- [Leads](https://developer.adobe.com/marketo-apis/api/mapi/#operation/syncLeadUsingPOST)
+- [Named Account Lists](https://developer.adobe.com/marketo-apis/api/mapi/#operation/syncNamedAccountListsUsingPOST)
+- [Named Accounts](https://developer.adobe.com/marketo-apis/api/mapi/#operation/syncNamedAccountsUsingPOST)
+- [Opportunities](https://developer.adobe.com/marketo-apis/api/mapi/#operation/syncOpportunitiesUsingPOST)
+- [Sales Persons](https://developer.adobe.com/marketo-apis/api/mapi/#operation/syncSalesPersonsUsingPOST)
 
 ## Using the connector
 


### PR DESCRIPTION
## Description
This PR updates links to marketo supported objects. Adds `Leads`, `Companies`, `SalesPersons` in read support as well.

Opening the object links needs waiting a little bit of seconds, it takes about 5 seconds for the link to fully open.

## Screenshot
<img width="1280" alt="Screenshot 2025-04-14 at 13 39 57" src="https://github.com/user-attachments/assets/a24ebdd6-1d59-49d1-be46-c23ef0c8b3f9" />

