### PR TITLE
[CON-1573] feat: add ClickUp Read action guides

### DIFF
--- a/src/provider-guides/clickup.mdx
+++ b/src/provider-guides/clickup.mdx
@@ -77,7 +77,7 @@ To start integrating with ClickUp:
 - Create a manifest file using the [example](https://github.com/amp-labs/samples/blob/main/clickup/amp.yaml).
 - Deploy it using the [amp CLI](/cli/overview).
 - If you are using Read Actions, create a [destination](/destinations).
-- Embed the [InstallIntegration](/embeddable-ui-components#install-integration) UI component. The UI component will prompt the customer for an API key.
+- Embed the [InstallIntegration](/embeddable-ui-components#install-integration) UI component. The UI component will prompt the customer for OAuth authorization.
 - Start using the connector!
    - If your integration has [Read Actions](/read-actions), you'll start getting webhook messages.
    - If your integration has [Proxy Actions](/proxy-actions), you can start making Proxy API calls.

--- a/src/provider-guides/clickup.mdx
+++ b/src/provider-guides/clickup.mdx
@@ -11,7 +11,7 @@ updatedAt: "Thu Jul 18 2024 06:13:12 GMT+0000 (Coordinated Universal Time)"
 ### Supported Actions
 
 This connector supports:
-- [Read Actions](/read-actions), including full historic backfill. Please note that incremental read is not supported, a full read of the Asana instance will be done for each scheduled read.
+- [Read Actions](/read-actions), including full historic backfill. Please note that incremental read is not supported, a full read of the Clickup instance will be done for each scheduled read.
 - [Proxy Actions](/proxy-actions), using the base URL `https://api.clickup.com`.
 
 ### Supported Objects

--- a/src/provider-guides/clickup.mdx
+++ b/src/provider-guides/clickup.mdx
@@ -11,11 +11,11 @@ updatedAt: "Thu Jul 18 2024 06:13:12 GMT+0000 (Coordinated Universal Time)"
 ### Supported Actions
 
 This connector supports:
-- [Read Actions](/read-actions), including full historic backfill. Please note that incremental read is not supported, a full read of the Clickup instance will be done for each scheduled read.
+- [Read Actions](/read-actions), including full historic backfill. Please note that incremental read is not supported, a full read of the ClickUp instance will be done for each scheduled read.
 - [Proxy Actions](/proxy-actions), using the base URL `https://api.clickup.com`.
 
 ### Supported Objects
-The Cickup connector supports reading from the following objects:
+The CickUp connector supports reading from the following objects:
 - [team](https://developer.clickup.com/reference/getauthorizedteams) (Read only)
 
 ## Before you get started
@@ -73,7 +73,7 @@ You'll use these credentials while connecting your app to Ampersand.
 
 ## Using the connector
 
-To start integrating with Clickup:
+To start integrating with ClickUp:
 - Create a manifest file using the [example](https://github.com/amp-labs/samples/blob/main/clickup/amp.yaml).
 - Deploy it using the [amp CLI](/cli/overview).
 - If you are using Read Actions, create a [destination](/destinations).

--- a/src/provider-guides/clickup.mdx
+++ b/src/provider-guides/clickup.mdx
@@ -11,9 +11,14 @@ updatedAt: "Thu Jul 18 2024 06:13:12 GMT+0000 (Coordinated Universal Time)"
 ### Supported Actions
 
 This connector supports:
+- [Read Actions](/read-actions), including full historic backfill. Please note that incremental read is not supported, a full read of the Asana instance will be done for each scheduled read.
 - [Proxy Actions](/proxy-actions), using the base URL `https://api.clickup.com`.
 
-## Before You Get Started
+### Supported Objects
+The Cickup connector supports reading from the following objects:
+- [team](https://developer.clickup.com/reference/getauthorizedteams) (Read only)
+
+## Before you get started
 
 To integrate ClickUp with Ampersand, you will need [a ClickUp Account](https://app.clickup.com/signup).
 
@@ -64,3 +69,15 @@ You'll use these credentials while connecting your app to Ampersand.
    ![Alt text](/images/provider-guides/d1a4278-clickup2.gif)
 
 6. Click **Save changes**.
+
+
+## Using the connector
+
+To start integrating with Clickup:
+- Create a manifest file using the [example](https://github.com/amp-labs/samples/blob/main/clickup/amp.yaml).
+- Deploy it using the [amp CLI](/cli/overview).
+- If you are using Read Actions, create a [destination](/destinations).
+- Embed the [InstallIntegration](/embeddable-ui-components#install-integration) UI component. The UI component will prompt the customer for an API key.
+- Start using the connector!
+   - If your integration has [Read Actions](/read-actions), you'll start getting webhook messages.
+   - If your integration has [Proxy Actions](/proxy-actions), you can start making Proxy API calls.


### PR DESCRIPTION
## Description
This PR adds guides for clickup deep connector and its supported objects.

> Clickup only supports one Read object and no Write objects.

## Screenshot
![localhost_3000_provider-guides_clickup](https://github.com/user-attachments/assets/62eb6feb-bc1b-4492-943d-f257b4742700)


