### PR TITLE
[CON-1545] feat(Aha): add guide for read and write

### DIFF
--- a/src/provider-guides/aha.mdx
+++ b/src/provider-guides/aha.mdx
@@ -18,7 +18,7 @@ This connector supports:
 
 ### Supported Objects
 
-The Aha! connector supports reading from the following objects:
+The Aha! connector supports writing to and reading from the following objects:
 - [audits](https://www.aha.io/api/resources/audits/retrieve_record_history) (incremental read)
 - [capacity_scenarios](https://www.aha.io/api/resources/capacity_scenarios/list_capacity_scenarios) (read)
 - [screen_definitions](https://www.aha.io/api/resources/custom_layouts/list_all_custom_layouts) (read)
@@ -44,7 +44,7 @@ The Aha! connector supports reading from the following objects:
 - [strategy_models](https://www.aha.io/api/resources/strategic_models/list_strategic_models) (read)
 - [strategy_positions](https://www.aha.io/api/resources/strategic_positionings/list_strategic_positionings) (read)
 - [strategy_visions](https://www.aha.io/api/resources/strategic_visions/list_strategic_visions) (read)
-- [team_members](https://www.aha.io/api/resources/team_members/list_virtual_team_members) (read,write)
+- [team_members](https://www.aha.io/api/resources/team_members/list_virtual_team_members) (read write)
 - [teams](https://www.aha.io/api/resources/teams/list_teams) (read)
 - [tasks](https://www.aha.io/api/resources/to-dos/list_approvals) (read, write)
 - [users](https://www.aha.io/api/resources/users/list_users) (read)
@@ -107,7 +107,7 @@ The OAuth applications tab shows **Client ID** and **Client Secret** keys.
 
 ![Img](/images/provider-guides/c425479-Aha3.gif)   
 
-6. Click **Save Changes:**
+6. Click **Save Changes**
 
 
 ## Using the connector

--- a/src/provider-guides/aha.mdx
+++ b/src/provider-guides/aha.mdx
@@ -11,7 +11,7 @@ updatedAt: "Thu Jul 18 2024 06:12:49 GMT+0000 (Coordinated Universal Time)"
 ### Supported Actions
 
 This connector supports:
-- [Read Actions](/read-actions), including full historic backfill. Please note that incremental read is supported only for `audits`, `historical_audits`, `ideas/endorsements` and `ideas` currently. For all other objects, a full read of the Aha instance will be done per scheduled read.
+- [Read Actions](/read-actions), including full historic backfill. Please note that incremental read is supported only for `audits`, `historical_audits`, `ideas/endorsements` and `ideas` currently. For all other objects, a full read of the Aha! instance will be done per scheduled read.
 - [Write Actions](/write-actions).
 - [Proxy Actions](/proxy-actions), using the base URL `https://{{.workspace}}.aha.io/api`.
 

--- a/src/provider-guides/aha.mdx
+++ b/src/provider-guides/aha.mdx
@@ -11,7 +11,44 @@ updatedAt: "Thu Jul 18 2024 06:12:49 GMT+0000 (Coordinated Universal Time)"
 ### Supported Actions
 
 This connector supports:
+- [Read Actions](/read-actions), including full historic backfill. Please note that incremental read is supported only for `audits`, `historical_audits`, `ideas/endorsements` and `ideas` currently. For all other objects, a full read of the Aha instance will be done per scheduled read.
+- [Write Actions](/write-actions).
 - [Proxy Actions](/proxy-actions), using the base URL `https://{{.workspace}}.aha.io/api`.
+
+
+### Supported Objects
+
+The Aha! connector supports reading from the following objects:
+- [audits](https://www.aha.io/api/resources/audits/retrieve_record_history) (incremental read)
+- [capacity_scenarios](https://www.aha.io/api/resources/capacity_scenarios/list_capacity_scenarios) (read)
+- [screen_definitions](https://www.aha.io/api/resources/custom_layouts/list_all_custom_layouts) (read)
+- [custom_field_definitions](https://www.aha.io/api/resources/custom_fields/list_all_custom_fields) (read)
+- [epics](https://www.aha.io/api/resources/epics/list_epics) (read)
+- [features](https://www.aha.io/api/resources/features/list_features) (read)
+- [goals](https://www.aha.io/api/resources/goals/list_goals) (read)
+- [historical_audits](https://www.aha.io/api/resources/historical_audits/read_the_contents_of_the_historical_index) (incremental read, write)
+- [idea_portals](https://www.aha.io/api/resources/idea_portals/list_all_idea_portals_in_an_account) (read)
+- [idea_organizations](https://www.aha.io/api/resources/idea_organizations/list_idea_organizations) (read, write)
+- [idea_users](https://www.aha.io/api/resources/idea_users/list_idea_users_for_an_account) (read, write)
+- [ideas](https://www.aha.io/api/resources/ideas/list_ideas) (incremental read)
+- [ideas/endorsements](https://www.aha.io/api/resources/idea_votes/list_votes_for_an_account) (incremental read)
+- [identity_providers](https://www.aha.io/api/resources/identity_providers/list_active_identity_providers_that_can_be_used_for_sso) (read)
+- [initiatives](https://www.aha.io/api/resources/initiatives/list_initiatives) (read)
+- [integrations](https://www.aha.io/api/resources/integrations/list_integrations_for_an_account) (read, write)
+- [me/tasks](https://www.aha.io/api/resources/me/list_pending_tasks_assigned_to_the_current_user) (read)
+- [me/assigned](https://www.aha.io/api/resources/me/list_records_assigned_to_the_current_user) (read)
+- [paid_seat_groups](https://www.aha.io/api/resources/paid_seat_groups/list_the_administered_paid_seat_groups) (read)
+- [products](https://www.aha.io/api/resources/products/list_products_with_idea_portals_in_the_account) (read, write)
+- [release_phases](https://www.aha.io/api/resources/release_phases/list_release_phases_in_the_account) (read, write)
+- [schedules](https://www.aha.io/api/resources/schedules/list_schedules) (read)
+- [strategy_models](https://www.aha.io/api/resources/strategic_models/list_strategic_models) (read)
+- [strategy_positions](https://www.aha.io/api/resources/strategic_positionings/list_strategic_positionings) (read)
+- [strategy_visions](https://www.aha.io/api/resources/strategic_visions/list_strategic_visions) (read)
+- [team_members](https://www.aha.io/api/resources/team_members/list_virtual_team_members) (read,write)
+- [teams](https://www.aha.io/api/resources/teams/list_teams) (read)
+- [tasks](https://www.aha.io/api/resources/to-dos/list_approvals) (read, write)
+- [users](https://www.aha.io/api/resources/users/list_users) (read)
+
 
 ## Before You Get Started
 
@@ -71,3 +108,16 @@ The OAuth applications tab shows **Client ID** and **Client Secret** keys.
 ![Img](/images/provider-guides/c425479-Aha3.gif)   
 
 6. Click **Save Changes:**
+
+
+## Using the connector
+
+To start integrating with Aha!:
+- Create a manifest file like the [example](https://github.com/amp-labs/samples/blob/main/aha/amp.yaml).
+- Deploy it using the [amp CLI](/cli/overview).
+- If you are using Read Actions, create a [destination](/destinations).
+- Embed the [InstallIntegration](/embeddable-ui-components#install-integration) UI component.
+- Start using the connector!
+   - If your integration has [Read Actions](/read-actions), you'll start getting webhook messages.
+   - If your integration has [Write Actions](/write-actions), you can start making API calls to our Write API.
+   - If your integration has [Proxy Actions](/proxy-actions), you can start making Proxy API calls.


### PR DESCRIPTION
## Description

This PR add guides for Aha Deep connectors and its supported objects.

## Screenshot
![localhost_3000_provider-guides_aha](https://github.com/user-attachments/assets/c4cb6ab7-ec83-414e-bb19-3d86b43f869b)
