### PR TITLE
fix: broken links mcp test

### DIFF
--- a/src/mcp.mdx
+++ b/src/mcp.mdx
@@ -43,4 +43,4 @@ If your MCP client does not support headers, you can pass the API key in the que
 
 ## Available tools
 
-The Ampersand MCP server exposes the same set of tools that are available in the [Ampersand AI SDK](/agents/sdk#available-tools).
+The Ampersand MCP server exposes the same set of tools that are available in the [Ampersand AI SDK](/ai-sdk#available-tools).


### PR DESCRIPTION
## Description
tests are breaking on the pipeline from this mcp links 
- note seems that mcp/agent pages are not exposed yet, no visible changes.
- update the mcp link to corrected path

### test
`yarn test:links`

## Screenshot
<img width="1409" alt="Screenshot 2025-05-30 at 12 17 20 PM" src="https://github.com/user-attachments/assets/24b1f347-5e04-44c2-ae5a-7688cd3c3d3d" />
