### PR TITLE
launch: release headless docs

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -33,7 +33,8 @@
               {
                 "group": "UI library",
                 "pages": [
-                  "embeddable-ui-components"
+                  "embeddable-ui-components",
+                  "headless"
                 ]
               },
               {

--- a/src/generate-docs.ts
+++ b/src/generate-docs.ts
@@ -248,7 +248,7 @@ const baseConfig = {
           group: "UI library",
           pages: [
             "embeddable-ui-components",
-            // "headless"
+            "headless"
           ]
         },
         {


### PR DESCRIPTION
## Description
release headless docs

## Screenshot
![Screenshot 2025-06-02 at 12 46 32 PM](https://github.com/user-attachments/assets/cc33875d-15d8-4f4f-96af-7db1c8fa2620)
