### PR TITLE
docs: add support for checking if all objects are installed

### DIFF
--- a/src/embeddable-ui-components.mdx
+++ b/src/embeddable-ui-components.mdx
@@ -162,6 +162,35 @@ const {
 } = useIsIntegrationInstalled("read-salesforce", groupRef);
 ```
 
+### Check if all objects are installed
+
+As of the most recent version, the `InstallIntegration` component will install as soon as the user saves a single object. Some flows require more 
+fine-grained control over when the entire installation or all objects are installed. To support this, we also give access to the [Config](/reference/installation/update-an-installation#body-installation-config-content) object 
+for developers to manage when specific objects are installed.
+
+```TypeScript
+const {
+  isLoaded,
+  isIntegrationInstalled, 
+  config,
+} = useIsIntegrationInstalled("read-salesforce", groupRef);
+
+// All 3 read objects are installed
+if (isLoaded && isIntegrationInstalled && config.read.objects.length === 3) {
+  // Do something 
+}
+
+// check if only the Account object is installed
+if (isLoaded && isIntegrationInstalled && config.read.objects.filter(o => o.objectName === "Account").length === 1) {
+  // Do something 
+}
+
+// All 3 write objects are installed
+if (isLoaded && isIntegrationInstalled && config.write.objects === 3) {
+  // Do something 
+}
+```
+
 ## Customize styles
 
 <Warning>Customized styling is only supported in v2.x.x </Warning>


### PR DESCRIPTION
## Description
One of the primary reasons that we're considering building an create flow is that builders need fine grain control over when the installation is complete. 

This PR adds docs so that the builder knows that they can use the config object to monitor if the installation is completed to what they expect. 

## Screenshot
![Screenshot 2025-06-04 at 6 01 07 PM](https://github.com/user-attachments/assets/9c056fae-9a57-42eb-99fc-f9ec9cbd184b)


