### PR TITLE
[CON-1939] chore: enhance quickstart documentation with Postman API reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 .DS_Store
-
-
+package-lock.json
 node_modules

--- a/src/quickstart.mdx
+++ b/src/quickstart.mdx
@@ -2,6 +2,13 @@
 title: "Quickstart"
 ---
 
+> **API Reference Available in Postman**  
+> If you prefer exploring APIs interactively, we've prepared a complete Postman collection that mirrors this quickstart. Each API call is pre-configured with examples.
+> 
+> <a href="https://app.getpostman.com/run-collection/45644907-32bc6952-6972-4ab4-b471-806f37ff67d3">
+>   <img src="https://run.pstmn.io/button.svg#noZoom" alt="Run in Postman" />
+> </a>
+
 For this Quickstart, we are going to build integrations for a cool new app called MailMonkey - an AI-powered email campaign manager that integrates with Salesforce. You can see the final `amp.yaml` file on [Github](https://github.com/amp-labs/samples/blob/main/salesforce/amp.yaml).
 
 <img width="300" src="/images/28feb09-Group_2987.png" />


### PR DESCRIPTION
## Description
Add a reference for Postman API collection and specific Quick Start collection so devs can follow along the [documentation](https://docs.withampersand.com/quickstart)
![image](https://github.com/user-attachments/assets/8c435d24-c23d-40ba-b554-ce028c117351)

## Screenshot
![WhatsApp Image 2025-06-05 at 10 08 10](https://github.com/user-attachments/assets/f10ab30b-2a00-4ff1-a1b1-ad3190d493d7)

