### PR TITLE
feat: extend Clari Copilot guide

### DIFF
--- a/src/provider-guides/clariCopilot.mdx
+++ b/src/provider-guides/clariCopilot.mdx
@@ -6,7 +6,18 @@ title: Clari Copilot
 ### Supported actions
 
 This connector supports:
+- [Read Actions](/read-actions), including full historic backfill. Please note that incremental read is not supported, a full read of the Customer Clari Copilot instance will be done for each scheduled read.
 - [Proxy Actions](/proxy-actions), using the base URL `https://rest-api.copilot.clari.com`.
+
+
+### Supported Objects
+
+The Clari Copilot connector supports reading from the following objects:
+- [calls](https://api-doc.copilot.clari.com/#tag/call/paths/~1calls/get) (read)
+- [users](https://api-doc.copilot.clari.com/#tag/user) (read)
+- [topics](https://api-doc.copilot.clari.com/#tag/topics/paths/~1v2~1topics/get) (read)
+- [scorecard](https://api-doc.copilot.clari.com/#tag/scorecard) (read)
+
 
 ### Example integration
 


### PR DESCRIPTION
## Description
This PR extends the guide of Clari Copilot to include Read operation guide.

## Screenshot
![localhost_3000_provider-guides_clariCopilot (1)](https://github.com/user-attachments/assets/ad27e388-144f-4e12-9143-4188fa983985)
