### PR TITLE
[CON-1838] feat (flatfile): extend guide to support read and write

### DIFF
--- a/src/provider-guides/flatfile.mdx
+++ b/src/provider-guides/flatfile.mdx
@@ -44,7 +44,7 @@ The Flatfile connector supports writing to the following objects:
 This connector uses API Key auth, which means that you do not need to set up a Provider App before getting started. Provider apps are only required for providers that use OAuth2 Authorization Code grant type.
 
 To start integrating with Flatfile:
-- Create a manifest file like the [example](https://github.com/amp-labs/samples/blob/main/flatFile/amp.yaml).
+- Create a manifest file like the [example](https://github.com/amp-labs/samples/blob/main/flatfile/amp.yaml).
 - Deploy it using the [amp CLI](/cli/overview).
 - If you are using Read Actions, create a [destination](/destinations).
 - Embed the [InstallIntegration](/embeddable-ui-components#install-integration) UI component. The UI component will prompt the customer for an API key.

--- a/src/provider-guides/flatfile.mdx
+++ b/src/provider-guides/flatfile.mdx
@@ -6,32 +6,52 @@ title: Flatfile
 ### Supported actions
 
 This connector supports:
+- [Read Actions](/read-actions), including full historic backfill. Please note that incremental read is supported only for `events`, currently. For all other objects, a full read of the Flatfile instance will be done per scheduled read.
+- [Write Actions](/write-actions).
 - [Proxy Actions](/proxy-actions), using the base URL `https://api.x.flatfile.com`.
 
-### Example integration
+### Supported Objects
 
-To define an integration for Flatfile, create a manifest file that looks like this:
+The Flatfile connector supports reading from the following objects:
 
-```YAML
-# amp.yaml
-specVersion: 1.0.0
-integrations:
-  - name: flatfile-integration
-    displayName: My Flatfile Integration
-    provider: flatfile
-    proxy:
-      enabled: true
-```
+- [apps](https://reference.flatfile.com/api-reference/apps/list)
+- [prompts](https://reference.flatfile.com/api-reference/assistant/list)
+- [environments](https://reference.flatfile.com/api-reference/environments/list)
+- [events](https://reference.flatfile.com/api-reference/events/list)
+- [files](https://reference.flatfile.com/api-reference/files/list)
+- [jobs](https://reference.flatfile.com/api-reference/jobs/list)
+- [mapping](https://reference.flatfile.com/api-reference/mapping/list-mapping-programs)
+- [roles](https://reference.flatfile.com/api-reference/roles/list)
+- [spaces](https://reference.flatfile.com/api-reference/spaces/list)
+- [users](https://reference.flatfile.com/api-reference/users/list)
+- [workbooks](https://reference.flatfile.com/api-reference/workbooks/list)
+
+The Flatfile connector supports writing to the following objects:
+
+- [apps](https://reference.flatfile.com/api-reference/apps/create)
+- [prompts](https://reference.flatfile.com/api-reference/assistant/create)
+- [environments](https://reference.flatfile.com/api-reference/environments/create)
+- [events](https://reference.flatfile.com/api-reference/events/create)
+- [files](https://reference.flatfile.com/api-reference/files/upload)
+- [jobs](https://reference.flatfile.com/api-reference/jobs/create)
+- [mapping](https://reference.flatfile.com/api-reference/mapping/create-mapping-program)
+- [spaces](https://reference.flatfile.com/api-reference/spaces/create)
+- [workbooks](https://reference.flatfile.com/api-reference/workbooks/create)
+
 
 ## Using the connector
 
 This connector uses API Key auth, which means that you do not need to set up a Provider App before getting started. Provider apps are only required for providers that use OAuth2 Authorization Code grant type.
 
 To start integrating with Flatfile:
-- Create a manifest file like the example above.
+- Create a manifest file like the [example](https://github.com/amp-labs/samples/blob/main/flatFile/amp.yaml).
 - Deploy it using the [amp CLI](/cli/overview).
+- If you are using Read Actions, create a [destination](/destinations).
 - Embed the [InstallIntegration](/embeddable-ui-components#install-integration) UI component. The UI component will prompt the customer for an API key.
-- Start making [Proxy Calls](/proxy-actions), and Ampersand will automatically attach the API key supplied by the customer. Please note that this connector's base URL is `https://platform.flatfile.com/api`.
+- Start using the connector!
+   - If your integration has [Read Actions](/read-actions), you'll start getting webhook messages.
+   - If your integration has [Write Actions](/write-actions), you can start making API calls to our Write API.
+   - If your integration has [Proxy Actions](/proxy-actions), you can start making Proxy API calls.
 
 
 

--- a/src/provider-guides/flatfile.mdx
+++ b/src/provider-guides/flatfile.mdx
@@ -6,7 +6,7 @@ title: Flatfile
 ### Supported actions
 
 This connector supports:
-- [Read Actions](/read-actions), including full historic backfill. Please note that incremental read is supported only for `events`, currently. For all other objects, a full read of the Flatfile instance will be done per scheduled read.
+- [Read Actions](/read-actions), including full historic backfill. Please note that incremental reading is only supported for `events`. For all other objects, a full read of the Flatfile instance will be done per scheduled read.
 - [Write Actions](/write-actions).
 - [Proxy Actions](/proxy-actions), using the base URL `https://api.x.flatfile.com`.
 


### PR DESCRIPTION
## Description
This PR extends Flatfile provider guides to support read and write. 

## Screenshot
<img width="3068" height="4866" alt="localhost_3000_provider-guides_flatfile (1)" src="https://github.com/user-attachments/assets/d381209b-ec28-49a9-b66b-55b4de9ce3ee" />
