### PR TITLE
[CON-891] fix(stripe): Add Disputes obj

### DIFF
--- a/src/provider-guides/stripe.mdx
+++ b/src/provider-guides/stripe.mdx
@@ -25,6 +25,7 @@ The Stripe connector supports reading from and writing to the following objects:
 * [coupons](https://docs.stripe.com/api/coupons/object) (incremental read supported)
 * [credit_notes](https://docs.stripe.com/api/credit_notes/object) (incremental read supported)
 * [customers](https://docs.stripe.com/api/customers/object) (incremental read supported)
+* [disputes](https://docs.stripe.com/api/disputes/object) (incremental read supported)
 * [entitlements/features](https://docs.stripe.com/api/entitlements/feature/object)
 * [file_links](https://docs.stripe.com/api/file_links/object) (incremental read supported)
 * [files](https://docs.stripe.com/api/files/object) (incremental read supported)


### PR DESCRIPTION
`Disputes` object should be mentioned in the docs. This was missed.
`Issuing/Disputes` is different and also exists in parallel.

ListObjectMetadata/Read are implemented for this object:
<img width="725" height="326" alt="image" src="https://github.com/user-attachments/assets/549be519-3805-4bc5-82b1-22283f7a8625" />
Issuing disputes too:
<img width="486" height="312" alt="image" src="https://github.com/user-attachments/assets/c50aec5d-a043-420d-8caf-980ffb31f3d3" />
