### PR TITLE
[CON-1354] feat: extend Teamleader provider guides

### DIFF
--- a/src/provider-guides/teamleader.mdx
+++ b/src/provider-guides/teamleader.mdx
@@ -65,7 +65,7 @@ The teamleader connector supports writing to the following objects:
 - [contacts](https://developer.focus.teamleader.eu/docs/api/contacts-add)
 - [companies](https://developer.focus.teamleader.eu/docs/api/companies-add)
 - [deals](https://developer.focus.teamleader.eu/docs/api/deals-create)
-- [events](https://developer.focus.teamleader.eu/docs/api/deals-create)
+- [events](https://developer.focus.teamleader.eu/docs/api/events-create)
 - [dealPipelines](https://developer.focus.teamleader.eu/docs/api/deal-pipelines-create)
 - [dealPhases](https://developer.focus.teamleader.eu/docs/api/deal-phases-create)
 - [quotations](https://developer.focus.teamleader.eu/docs/api/quotations-create)


### PR DESCRIPTION
## Description
This PR extends the Teamleader provider guides to support Read and Write action.

## Screenshot
<img width="2894" height="11280" alt="localhost_3000_provider-guides_teamleader" src="https://github.com/user-attachments/assets/20c97fc1-17c9-419b-a29d-57865684d9ea" />
