### PR TITLE
docs: update headless docs with updated useLocalConfig hook

### DIFF
--- a/src/headless.mdx
+++ b/src/headless.mdx
@@ -330,7 +330,7 @@ Managing the [Config](/terminology#config) that keeps track of each customer's p
 The `useLocalConfig` hook simplifies local state management of the config object by providing flexible utilities to manipulate the config through a set of setters and getters. It maintains a draft state, which you can modify before committing changes to the installation.
 
 <Note>
-**Deprecated:** `useConfig` has been deprecated in React 2.9.0 to prevent confusion. Use `useLocalConfig()` for managing local config draft state instead.
+**Deprecated:** `useConfig` has been deprecated in v2.9.0. It has been renamed to `useLocalConfig()` without any other changes.
 
 For fetching an existing config from an installation, use [`useInstallation`](#get-current-installation) which provides access to the current installation's configuration.
 </Note>

--- a/src/headless.mdx
+++ b/src/headless.mdx
@@ -190,7 +190,7 @@ function ConfigDisplayComponent() {
 ```
 
 <Note>
-For more advanced config management: including getting/setting read/write objects in the config and managing a local draft copy, use the [`useLocalConfig()`](#config-management) helper hook.
+For more advanced config management: including getting/setting read/write objects in the config and managing a local draft copy, use the [`useLocalConfig()`](#config-management) hook.
 </Note>
 
 ### Create, update, and delete installations

--- a/src/headless.mdx
+++ b/src/headless.mdx
@@ -168,6 +168,31 @@ function InstallationComponent() {
 }
 ```
 
+### Get config from existing installation
+
+To access the configuration from an existing installation, you can use the `installation.config` property. The config structure follows the same format as described in the [API reference](/reference/installation/get-an-installation#response-config):
+
+```tsx
+import { useInstallation } from '@amp-labs/react';
+
+function ConfigDisplayComponent() {
+  const { installation } = useInstallation();
+
+  if (!installation) {
+    return <div>No installation found</div>;
+  }
+
+  // Access the configuration from the installation
+  const config = installation.config;
+
+  // Use the config to build your custom UI
+}
+```
+
+<Note>
+For more advanced config management including getting and setting specific parts of the config and managing a local draft copy, use the [`useLocalConfig()`](#config-management) helper hook.
+</Note>
+
 ### Create, update, and delete installations
 
 The following hooks provide granular control over [Installation](/concepts#installation) operations:

--- a/src/headless.mdx
+++ b/src/headless.mdx
@@ -190,7 +190,7 @@ function ConfigDisplayComponent() {
 ```
 
 <Note>
-For more advanced config management including getting and setting specific parts of the config and managing a local draft copy, use the [`useLocalConfig()`](#config-management) helper hook.
+For more advanced config management: including getting/setting read/write objects in the config and managing a local draft copy, use the [`useLocalConfig()`](#config-management) helper hook.
 </Note>
 
 ### Create, update, and delete installations

--- a/src/headless.mdx
+++ b/src/headless.mdx
@@ -170,7 +170,7 @@ function InstallationComponent() {
 
 ### Get config from existing installation
 
-To access the configuration from an existing installation, you can use the `installation.config` property. The config structure follows the same format as described in the [API reference](/reference/installation/get-an-installation#response-config):
+To access the configuration from an existing installation, you can use the `installation.config` property. See [API reference](/reference/installation/get-an-installation#response-config) for more details:
 
 ```tsx
 import { useInstallation } from '@amp-labs/react';

--- a/src/headless.mdx
+++ b/src/headless.mdx
@@ -302,12 +302,18 @@ The `getCustomerFieldsForObject` function returned by `useManifest` allows you t
 
 Managing the [Config](/terminology#config) that keeps track of each customer's preference for how the integration behaves can be complex, with deeply nested objects and the need to manage this state locally.
 
-The `useConfig` hook simplifies local state management of the config object by providing flexible utilities to manipulate the config through a set of setters and getters. It maintains a draft state, which you can modify before committing changes to the installation.
+The `useLocalConfig` hook simplifies local state management of the config object by providing flexible utilities to manipulate the config through a set of setters and getters. It maintains a draft state, which you can modify before committing changes to the installation.
+
+<Note>
+**Deprecated:** `useConfig` has been deprecated in React 2.9.0 to prevent confusion. Use `useLocalConfig()` for managing local config draft state instead.
+
+For fetching an existing config from an installation, use [`useInstallation`](#get-current-installation) which provides access to the current installation's configuration.
+</Note>
 
 It returns these fields:
 
 ```typescript
-// Return values of `useConfig` hook.
+// Return values of `useLocalConfig` hook.
 {
   draft: InstallationConfigContent;  // Current draft configuration
   get: () => InstallationConfigContent;  // Get current configuration
@@ -367,7 +373,7 @@ This is a basic example that hard-codes a Config and does not allow the user to 
 
 ```typescript
 function ConfigManager() {
-  const config = useConfig();
+  const config = useLocalConfig();
   const { createInstallation } = useCreateInstallation();
   
   config.setDraft({
@@ -403,7 +409,7 @@ This is an example for how to use helper functions to more easily construct a re
 
 ```typescript
 function ReadObjectConfig() {
-  const config = useConfig();
+  const config = useLocalConfig();
   const contactConfig = config.readObject("Contact");
   
   // Check if field is selected
@@ -429,7 +435,7 @@ The headless UI library provides helper functions to more easily construct a wri
 
 ```typescript
 function WriteObjectConfig() {
-  const config = useConfig();
+  const config = useLocalConfig();
   const contactWriteConfig = config.writeObject("Contact");
   
   // Enable write for Contact object
@@ -447,7 +453,7 @@ You can configure write settings for individual features using these methods:
 
 ```typescript
 function WriteObjectConfig() {
-  const config = useConfig();
+  const config = useLocalConfig();
   const contactWriteConfig = config.writeObject("Contact");
   
   // Set default value for a field
@@ -507,7 +513,7 @@ You can use `setFieldSettings` to set all advanced write features at once for a 
 
 ```typescript
 function WriteObjectConfig() {
-  const config = useConfig();
+  const config = useLocalConfig();
   const contactWriteConfig = config.writeObject("Contact");
   
   // Configure a field with both write behavior and default value
@@ -533,7 +539,7 @@ Here's a full example that uses the `ReadObjectConfig` and `WriteObjectConfig` c
 
 ```typescript
 function IntegrationConfig() {
-  const config = useConfig();
+  const config = useLocalConfig();
   const { updateInstallation } = useUpdateInstallation();
   
   const handleSave = async () => {

--- a/src/write-actions.mdx
+++ b/src/write-actions.mdx
@@ -141,7 +141,7 @@ You can set overwrite behavior on a customer-by-customer basis when using the fu
 
 ```typescript
 function WriteObjectConfig() {
-  const config = useConfig();
+  const config = useLocalConfig();
   const contactWriteConfig = config.writeObject("Contact");
 
   // Only write to source field when creating a record, not when updating
@@ -198,7 +198,7 @@ You can set default values on a customer-by-customer basis using the `setFieldSe
 
 ```typescript
 function WriteObjectConfig() {
-  const config = useConfig();
+  const config = useLocalConfig();
   const contactWriteConfig = config.writeObject("Contact");
 
   // Set default values for fields


### PR DESCRIPTION
### Summary

  - Added example in Installation management section showing how to get config from existing installation using installation.config
  - Added note directing users to useLocalConfig() hook for advanced config management
  - Linked to API reference documentation for config structure details

  Test plan

  - Verify the new example renders correctly in the documentation
  - Confirm internal links work properly (API reference and config management section)
  - Review example code for accuracy and completeness
Please include a screenshot of the documentation running locally with `cd src && mint dev`. 
