### PR TITLE
[ENG-2613]update-marketo-provider-guide

### DIFF
--- a/src/provider-guides/marketo.mdx
+++ b/src/provider-guides/marketo.mdx
@@ -13,26 +13,26 @@ This connector supports:
 ### Supported Objects
 The Marketo connector supports reading from the following objects:
 
-- [campaigns](https://developer.adobe.com/marketo-apis/api/mapi/#operation/getCampaignsUsingGET)
-- [companies](https://developer.adobe.com/marketo-apis/api/mapi/#operation/getCompaniesUsingGET)
-- [customobjects](https://developer.adobe.com/marketo-apis/api/mapi/#operation/listCustomObjectsUsingGET)
-- [leads](https://developer.adobe.com/marketo-apis/api/mapi/#operation/getLeadsByFilterUsingGET)
-- [lists](https://developer.adobe.com/marketo-apis/api/mapi/#operation/getListsUsingGET)
-- [salespersons](https://developer.adobe.com/marketo-apis/api/mapi/#operation/getSalesPersonUsingGET)
-- [activities](https://developer.adobe.com/marketo-apis/api/mapi/#operation/getLeadActivitiesUsingGET)
+- [campaigns](https://experienceleague.adobe.com/en/docs/marketo-developer/marketo/rest/assets/smart-campaigns#query)
+- [companies](https://experienceleague.adobe.com/en/docs/marketo-developer/marketo/rest/lead-database/companies#query)
+- [customobjects](https://experienceleague.adobe.com/en/docs/marketo-developer/marketo/rest/lead-database/custom-objects#list)
+- [leads](https://experienceleague.adobe.com/en/docs/marketo-developer/marketo/rest/lead-database/leads#query)
+- [lists](https://experienceleague.adobe.com/en/docs/marketo-developer/marketo/rest/assets/static-lists#query)
+- [salespersons](https://experienceleague.adobe.com/en/docs/marketo-developer/marketo/rest/lead-database/sales-persons#query)
+- [activities](https://experienceleague.adobe.com/en/docs/marketo-developer/marketo/rest/lead-database/activities#query)
 
 activities is supported in private preview only and you need to contact `support@withampersand.com`
 
 The Marketo connector supports writing to the following objects:
 
-- [companies](https://developer.adobe.com/marketo-apis/api/mapi/#operation/syncCompaniesUsingPOST)
-- [leads](https://developer.adobe.com/marketo-apis/api/mapi/#operation/syncLeadUsingPOST)
-- [namedAccountLists](https://developer.adobe.com/marketo-apis/api/mapi/#operation/syncNamedAccountListsUsingPOST)
-- [namedaccounts](https://developer.adobe.com/marketo-apis/api/mapi/#operation/syncNamedAccountsUsingPOST)
-- [opportunities](https://developer.adobe.com/marketo-apis/api/mapi/#operation/syncOpportunitiesUsingPOST)
-- [salespersons](https://developer.adobe.com/marketo-apis/api/mapi/#operation/syncSalesPersonsUsingPOST)
-- [custom activities](https://developer.adobe.com/marketo-apis/api/mapi/#operation/addCustomActivityUsingPOST)
-- [activity type](https://developer.adobe.com/marketo-apis/api/mapi/#operation/createCustomActivityTypeUsingPOST)
+- [companies](https://experienceleague.adobe.com/en/docs/marketo-developer/marketo/rest/lead-database/companies#create-and-update)
+- [leads](https://experienceleague.adobe.com/en/docs/marketo-developer/marketo/rest/lead-database/leads#create-and-update)
+- [namedAccountLists](https://experienceleague.adobe.com/en/docs/marketo-developer/marketo/rest/lead-database/named-account-lists#create-and-update)
+- [namedaccounts](https://experienceleague.adobe.com/en/docs/marketo-developer/marketo/rest/lead-database/named-accounts#create-and-update)
+- [opportunities](https://experienceleague.adobe.com/en/docs/marketo-developer/marketo/rest/lead-database/opportunities#create-and-update)
+- [salespersons](https://experienceleague.adobe.com/en/docs/marketo-developer/marketo/rest/lead-database/sales-persons#create-and-update)
+- [custom activities](https://experienceleague.adobe.com/en/docs/marketo-developer/marketo/rest/lead-database/activities#create-type)
+- [activity type](https://experienceleague.adobe.com/en/docs/marketo-developer/marketo/rest/lead-database/activities#custom-activity-type-attributes)
 
 ## Using the connector
 


### PR DESCRIPTION
## Description
This is to update marketo provider guide with the newer version of the API docs.

## Screenshot

Please include a screenshot of the documentation running locally with `cd src && mint dev`. 
<img width="895" height="828" alt="Screenshot 2025-09-25 at 3 59 08 PM" src="https://github.com/user-attachments/assets/2b8fbfaa-24c4-4297-95a2-ec1e36105d48" />

* Pulled up the local preview to see if they are re-directing to the new links that have been added 
<img width="1467" height="983" alt="Screenshot 2025-09-25 at 3 59 55 PM" src="https://github.com/user-attachments/assets/eb804c86-bf80-4008-808a-4606634baf54" />
