### PR TITLE
chore(dynamicsCRM): Update objects to plural

### DIFF
--- a/src/platform.json
+++ b/src/platform.json
@@ -12044,13 +12044,13 @@
                             "type": "string",
                             "description": "The time the group was created.",
                             "format": "date-time",
-                            "example": "2023-07-13T21:34:44.816Z"
+                            "example": "2023-07-13T21:34:44.816354Z"
                           },
                           "updateTime": {
                             "type": "string",
                             "description": "The time the group was last updated.",
                             "format": "date-time",
-                            "example": "2023-07-13T21:34:44.816Z"
+                            "example": "2023-07-13T21:34:44.816354Z"
                           }
                         }
                       },
@@ -12191,13 +12191,13 @@
                                 "type": "string",
                                 "description": "The time the group was created.",
                                 "format": "date-time",
-                                "example": "2023-07-13T21:34:44.816Z"
+                                "example": "2023-07-13T21:34:44.816354Z"
                               },
                               "updateTime": {
                                 "type": "string",
                                 "description": "The time the group was last updated.",
                                 "format": "date-time",
-                                "example": "2023-07-13T21:34:44.816Z"
+                                "example": "2023-07-13T21:34:44.816354Z"
                               }
                             }
                           },
@@ -12230,13 +12230,13 @@
                                 "type": "string",
                                 "description": "The time the consumer was created.",
                                 "format": "date-time",
-                                "example": "2023-07-13T21:34:44.816Z"
+                                "example": "2023-07-13T21:34:44.816354Z"
                               },
                               "updateTime": {
                                 "type": "string",
                                 "description": "The time the consumer was last updated.",
                                 "format": "date-time",
-                                "example": "2023-07-13T21:34:44.816Z"
+                                "example": "2023-07-13T21:34:44.816354Z"
                               }
                             }
                           },
@@ -12254,13 +12254,13 @@
                             "type": "string",
                             "description": "The time the connection was created.",
                             "format": "date-time",
-                            "example": "2023-07-13T21:34:44.816Z"
+                            "example": "2023-07-13T21:34:44.816354Z"
                           },
                           "updateTime": {
                             "type": "string",
                             "description": "The time the connection was last updated.",
                             "format": "date-time",
-                            "example": "2023-07-13T21:34:44.816Z"
+                            "example": "2023-07-13T21:34:44.816354Z"
                           },
                           "authScheme": {
                             "type": "string",
@@ -12611,7 +12611,7 @@
                                                     }
                                                   }
                                                 },
-                                                "filter": {
+                                                "fieldFilters": {
                                                   "type": "array",
                                                   "description": "Filters to apply only during backfill. Multiple conditions are joined by AND. Use this when you want different filter behavior for backfill vs. incremental reads.\n",
                                                   "x-go-type-skip-optional-pointer": true,
@@ -12646,7 +12646,7 @@
                                                 }
                                               }
                                             },
-                                            "filter": {
+                                            "fieldFilters": {
                                               "type": "array",
                                               "description": "Filters to apply when reading records during incremental reads and backfill. Multiple conditions are joined by AND. Each field can only have one condition.\n",
                                               "x-go-type-skip-optional-pointer": true,
@@ -13041,7 +13041,7 @@
                                                         }
                                                       }
                                                     },
-                                                    "filter": {
+                                                    "fieldFilters": {
                                                       "type": "array",
                                                       "description": "Filters to apply only during backfill. Multiple conditions are joined by AND. Use this when you want different filter behavior for backfill vs. incremental reads.\n",
                                                       "x-go-type-skip-optional-pointer": true,
@@ -13076,7 +13076,7 @@
                                                     }
                                                   }
                                                 },
-                                                "filter": {
+                                                "fieldFilters": {
                                                   "type": "array",
                                                   "description": "Filters to apply when reading records during incremental reads and backfill. Multiple conditions are joined by AND. Each field can only have one condition.\n",
                                                   "x-go-type-skip-optional-pointer": true,
@@ -13286,7 +13286,7 @@
                                                             }
                                                           }
                                                         },
-                                                        "filter": {
+                                                        "fieldFilters": {
                                                           "type": "array",
                                                           "description": "Filters to apply only during backfill. Multiple conditions are joined by AND. Use this when you want different filter behavior for backfill vs. incremental reads.\n",
                                                           "x-go-type-skip-optional-pointer": true,
@@ -13321,7 +13321,7 @@
                                                         }
                                                       }
                                                     },
-                                                    "filter": {
+                                                    "fieldFilters": {
                                                       "type": "array",
                                                       "description": "Filters to apply when reading records during incremental reads and backfill. Multiple conditions are joined by AND. Each field can only have one condition.\n",
                                                       "x-go-type-skip-optional-pointer": true,
@@ -14598,7 +14598,6 @@
                         "default": "api:create-installation"
                       },
                       "content": {
-                        "description": "The content of the config.",
                         "title": "Config Content",
                         "allOf": [
                           {
@@ -14779,7 +14778,7 @@
                                                 }
                                               }
                                             },
-                                            "filter": {
+                                            "fieldFilters": {
                                               "type": "array",
                                               "description": "Filters to apply only during backfill. Multiple conditions are joined by AND. Use this when you want different filter behavior for backfill vs. incremental reads.\n",
                                               "x-go-type-skip-optional-pointer": true,
@@ -14814,7 +14813,7 @@
                                             }
                                           }
                                         },
-                                        "filter": {
+                                        "fieldFilters": {
                                           "type": "array",
                                           "description": "Filters to apply when reading records during incremental reads and backfill. Multiple conditions are joined by AND. Each field can only have one condition.\n",
                                           "x-go-type-skip-optional-pointer": true,
@@ -15209,7 +15208,7 @@
                                                     }
                                                   }
                                                 },
-                                                "filter": {
+                                                "fieldFilters": {
                                                   "type": "array",
                                                   "description": "Filters to apply only during backfill. Multiple conditions are joined by AND. Use this when you want different filter behavior for backfill vs. incremental reads.\n",
                                                   "x-go-type-skip-optional-pointer": true,
@@ -15244,7 +15243,7 @@
                                                 }
                                               }
                                             },
-                                            "filter": {
+                                            "fieldFilters": {
                                               "type": "array",
                                               "description": "Filters to apply when reading records during incremental reads and backfill. Multiple conditions are joined by AND. Each field can only have one condition.\n",
                                               "x-go-type-skip-optional-pointer": true,
@@ -15454,7 +15453,7 @@
                                                         }
                                                       }
                                                     },
-                                                    "filter": {
+                                                    "fieldFilters": {
                                                       "type": "array",
                                                       "description": "Filters to apply only during backfill. Multiple conditions are joined by AND. Use this when you want different filter behavior for backfill vs. incremental reads.\n",
                                                       "x-go-type-skip-optional-pointer": true,
@@ -15489,7 +15488,7 @@
                                                     }
                                                   }
                                                 },
-                                                "filter": {
+                                                "fieldFilters": {
                                                   "type": "array",
                                                   "description": "Filters to apply when reading records during incremental reads and backfill. Multiple conditions are joined by AND. Each field can only have one condition.\n",
                                                   "x-go-type-skip-optional-pointer": true,
@@ -16171,7 +16170,8 @@
                               }
                             }
                           }
-                        ]
+                        ],
+                        "description": "The content of the config."
                       }
                     },
                     "description": "The config of the installation."
@@ -16308,13 +16308,13 @@
                           "type": "string",
                           "description": "The time the group was created.",
                           "format": "date-time",
-                          "example": "2023-07-13T21:34:44.816Z"
+                          "example": "2023-07-13T21:34:44.816354Z"
                         },
                         "updateTime": {
                           "type": "string",
                           "description": "The time the group was last updated.",
                           "format": "date-time",
-                          "example": "2023-07-13T21:34:44.816Z"
+                          "example": "2023-07-13T21:34:44.816354Z"
                         }
                       }
                     },
@@ -16455,13 +16455,13 @@
                               "type": "string",
                               "description": "The time the group was created.",
                               "format": "date-time",
-                              "example": "2023-07-13T21:34:44.816Z"
+                              "example": "2023-07-13T21:34:44.816354Z"
                             },
                             "updateTime": {
                               "type": "string",
                               "description": "The time the group was last updated.",
                               "format": "date-time",
-                              "example": "2023-07-13T21:34:44.816Z"
+                              "example": "2023-07-13T21:34:44.816354Z"
                             }
                           }
                         },
@@ -16494,13 +16494,13 @@
                               "type": "string",
                               "description": "The time the consumer was created.",
                               "format": "date-time",
-                              "example": "2023-07-13T21:34:44.816Z"
+                              "example": "2023-07-13T21:34:44.816354Z"
                             },
                             "updateTime": {
                               "type": "string",
                               "description": "The time the consumer was last updated.",
                               "format": "date-time",
-                              "example": "2023-07-13T21:34:44.816Z"
+                              "example": "2023-07-13T21:34:44.816354Z"
                             }
                           }
                         },
@@ -16518,13 +16518,13 @@
                           "type": "string",
                           "description": "The time the connection was created.",
                           "format": "date-time",
-                          "example": "2023-07-13T21:34:44.816Z"
+                          "example": "2023-07-13T21:34:44.816354Z"
                         },
                         "updateTime": {
                           "type": "string",
                           "description": "The time the connection was last updated.",
                           "format": "date-time",
-                          "example": "2023-07-13T21:34:44.816Z"
+                          "example": "2023-07-13T21:34:44.816354Z"
                         },
                         "authScheme": {
                           "type": "string",
@@ -16875,7 +16875,7 @@
                                                   }
                                                 }
                                               },
-                                              "filter": {
+                                              "fieldFilters": {
                                                 "type": "array",
                                                 "description": "Filters to apply only during backfill. Multiple conditions are joined by AND. Use this when you want different filter behavior for backfill vs. incremental reads.\n",
                                                 "x-go-type-skip-optional-pointer": true,
@@ -16910,7 +16910,7 @@
                                               }
                                             }
                                           },
-                                          "filter": {
+                                          "fieldFilters": {
                                             "type": "array",
                                             "description": "Filters to apply when reading records during incremental reads and backfill. Multiple conditions are joined by AND. Each field can only have one condition.\n",
                                             "x-go-type-skip-optional-pointer": true,
@@ -17305,7 +17305,7 @@
                                                       }
                                                     }
                                                   },
-                                                  "filter": {
+                                                  "fieldFilters": {
                                                     "type": "array",
                                                     "description": "Filters to apply only during backfill. Multiple conditions are joined by AND. Use this when you want different filter behavior for backfill vs. incremental reads.\n",
                                                     "x-go-type-skip-optional-pointer": true,
@@ -17340,7 +17340,7 @@
                                                   }
                                                 }
                                               },
-                                              "filter": {
+                                              "fieldFilters": {
                                                 "type": "array",
                                                 "description": "Filters to apply when reading records during incremental reads and backfill. Multiple conditions are joined by AND. Each field can only have one condition.\n",
                                                 "x-go-type-skip-optional-pointer": true,
@@ -17550,7 +17550,7 @@
                                                           }
                                                         }
                                                       },
-                                                      "filter": {
+                                                      "fieldFilters": {
                                                         "type": "array",
                                                         "description": "Filters to apply only during backfill. Multiple conditions are joined by AND. Use this when you want different filter behavior for backfill vs. incremental reads.\n",
                                                         "x-go-type-skip-optional-pointer": true,
@@ -17585,7 +17585,7 @@
                                                       }
                                                     }
                                                   },
-                                                  "filter": {
+                                                  "fieldFilters": {
                                                     "type": "array",
                                                     "description": "Filters to apply when reading records during incremental reads and backfill. Multiple conditions are joined by AND. Each field can only have one condition.\n",
                                                     "x-go-type-skip-optional-pointer": true,
@@ -19164,13 +19164,13 @@
                           "type": "string",
                           "description": "The time the group was created.",
                           "format": "date-time",
-                          "example": "2023-07-13T21:34:44.816Z"
+                          "example": "2023-07-13T21:34:44.816354Z"
                         },
                         "updateTime": {
                           "type": "string",
                           "description": "The time the group was last updated.",
                           "format": "date-time",
-                          "example": "2023-07-13T21:34:44.816Z"
+                          "example": "2023-07-13T21:34:44.816354Z"
                         }
                       }
                     },
@@ -19311,13 +19311,13 @@
                               "type": "string",
                               "description": "The time the group was created.",
                               "format": "date-time",
-                              "example": "2023-07-13T21:34:44.816Z"
+                              "example": "2023-07-13T21:34:44.816354Z"
                             },
                             "updateTime": {
                               "type": "string",
                               "description": "The time the group was last updated.",
                               "format": "date-time",
-                              "example": "2023-07-13T21:34:44.816Z"
+                              "example": "2023-07-13T21:34:44.816354Z"
                             }
                           }
                         },
@@ -19350,13 +19350,13 @@
                               "type": "string",
                               "description": "The time the consumer was created.",
                               "format": "date-time",
-                              "example": "2023-07-13T21:34:44.816Z"
+                              "example": "2023-07-13T21:34:44.816354Z"
                             },
                             "updateTime": {
                               "type": "string",
                               "description": "The time the consumer was last updated.",
                               "format": "date-time",
-                              "example": "2023-07-13T21:34:44.816Z"
+                              "example": "2023-07-13T21:34:44.816354Z"
                             }
                           }
                         },
@@ -19374,13 +19374,13 @@
                           "type": "string",
                           "description": "The time the connection was created.",
                           "format": "date-time",
-                          "example": "2023-07-13T21:34:44.816Z"
+                          "example": "2023-07-13T21:34:44.816354Z"
                         },
                         "updateTime": {
                           "type": "string",
                           "description": "The time the connection was last updated.",
                           "format": "date-time",
-                          "example": "2023-07-13T21:34:44.816Z"
+                          "example": "2023-07-13T21:34:44.816354Z"
                         },
                         "authScheme": {
                           "type": "string",
@@ -19731,7 +19731,7 @@
                                                   }
                                                 }
                                               },
-                                              "filter": {
+                                              "fieldFilters": {
                                                 "type": "array",
                                                 "description": "Filters to apply only during backfill. Multiple conditions are joined by AND. Use this when you want different filter behavior for backfill vs. incremental reads.\n",
                                                 "x-go-type-skip-optional-pointer": true,
@@ -19766,7 +19766,7 @@
                                               }
                                             }
                                           },
-                                          "filter": {
+                                          "fieldFilters": {
                                             "type": "array",
                                             "description": "Filters to apply when reading records during incremental reads and backfill. Multiple conditions are joined by AND. Each field can only have one condition.\n",
                                             "x-go-type-skip-optional-pointer": true,
@@ -20161,7 +20161,7 @@
                                                       }
                                                     }
                                                   },
-                                                  "filter": {
+                                                  "fieldFilters": {
                                                     "type": "array",
                                                     "description": "Filters to apply only during backfill. Multiple conditions are joined by AND. Use this when you want different filter behavior for backfill vs. incremental reads.\n",
                                                     "x-go-type-skip-optional-pointer": true,
@@ -20196,7 +20196,7 @@
                                                   }
                                                 }
                                               },
-                                              "filter": {
+                                              "fieldFilters": {
                                                 "type": "array",
                                                 "description": "Filters to apply when reading records during incremental reads and backfill. Multiple conditions are joined by AND. Each field can only have one condition.\n",
                                                 "x-go-type-skip-optional-pointer": true,
@@ -20406,7 +20406,7 @@
                                                           }
                                                         }
                                                       },
-                                                      "filter": {
+                                                      "fieldFilters": {
                                                         "type": "array",
                                                         "description": "Filters to apply only during backfill. Multiple conditions are joined by AND. Use this when you want different filter behavior for backfill vs. incremental reads.\n",
                                                         "x-go-type-skip-optional-pointer": true,
@@ -20441,7 +20441,7 @@
                                                       }
                                                     }
                                                   },
-                                                  "filter": {
+                                                  "fieldFilters": {
                                                     "type": "array",
                                                     "description": "Filters to apply when reading records during incremental reads and backfill. Multiple conditions are joined by AND. Each field can only have one condition.\n",
                                                     "x-go-type-skip-optional-pointer": true,
@@ -22089,7 +22089,7 @@
                                                     }
                                                   }
                                                 },
-                                                "filter": {
+                                                "fieldFilters": {
                                                   "type": "array",
                                                   "description": "Filters to apply only during backfill. Multiple conditions are joined by AND. Use this when you want different filter behavior for backfill vs. incremental reads.\n",
                                                   "x-go-type-skip-optional-pointer": true,
@@ -22124,7 +22124,7 @@
                                                 }
                                               }
                                             },
-                                            "filter": {
+                                            "fieldFilters": {
                                               "type": "array",
                                               "description": "Filters to apply when reading records during incremental reads and backfill. Multiple conditions are joined by AND. Each field can only have one condition.\n",
                                               "x-go-type-skip-optional-pointer": true,
@@ -22576,13 +22576,13 @@
                           "type": "string",
                           "description": "The time the group was created.",
                           "format": "date-time",
-                          "example": "2023-07-13T21:34:44.816Z"
+                          "example": "2023-07-13T21:34:44.816354Z"
                         },
                         "updateTime": {
                           "type": "string",
                           "description": "The time the group was last updated.",
                           "format": "date-time",
-                          "example": "2023-07-13T21:34:44.816Z"
+                          "example": "2023-07-13T21:34:44.816354Z"
                         }
                       }
                     },
@@ -22723,13 +22723,13 @@
                               "type": "string",
                               "description": "The time the group was created.",
                               "format": "date-time",
-                              "example": "2023-07-13T21:34:44.816Z"
+                              "example": "2023-07-13T21:34:44.816354Z"
                             },
                             "updateTime": {
                               "type": "string",
                               "description": "The time the group was last updated.",
                               "format": "date-time",
-                              "example": "2023-07-13T21:34:44.816Z"
+                              "example": "2023-07-13T21:34:44.816354Z"
                             }
                           }
                         },
@@ -22762,13 +22762,13 @@
                               "type": "string",
                               "description": "The time the consumer was created.",
                               "format": "date-time",
-                              "example": "2023-07-13T21:34:44.816Z"
+                              "example": "2023-07-13T21:34:44.816354Z"
                             },
                             "updateTime": {
                               "type": "string",
                               "description": "The time the consumer was last updated.",
                               "format": "date-time",
-                              "example": "2023-07-13T21:34:44.816Z"
+                              "example": "2023-07-13T21:34:44.816354Z"
                             }
                           }
                         },
@@ -22786,13 +22786,13 @@
                           "type": "string",
                           "description": "The time the connection was created.",
                           "format": "date-time",
-                          "example": "2023-07-13T21:34:44.816Z"
+                          "example": "2023-07-13T21:34:44.816354Z"
                         },
                         "updateTime": {
                           "type": "string",
                           "description": "The time the connection was last updated.",
                           "format": "date-time",
-                          "example": "2023-07-13T21:34:44.816Z"
+                          "example": "2023-07-13T21:34:44.816354Z"
                         },
                         "authScheme": {
                           "type": "string",
@@ -23143,7 +23143,7 @@
                                                   }
                                                 }
                                               },
-                                              "filter": {
+                                              "fieldFilters": {
                                                 "type": "array",
                                                 "description": "Filters to apply only during backfill. Multiple conditions are joined by AND. Use this when you want different filter behavior for backfill vs. incremental reads.\n",
                                                 "x-go-type-skip-optional-pointer": true,
@@ -23178,7 +23178,7 @@
                                               }
                                             }
                                           },
-                                          "filter": {
+                                          "fieldFilters": {
                                             "type": "array",
                                             "description": "Filters to apply when reading records during incremental reads and backfill. Multiple conditions are joined by AND. Each field can only have one condition.\n",
                                             "x-go-type-skip-optional-pointer": true,
@@ -23573,7 +23573,7 @@
                                                       }
                                                     }
                                                   },
-                                                  "filter": {
+                                                  "fieldFilters": {
                                                     "type": "array",
                                                     "description": "Filters to apply only during backfill. Multiple conditions are joined by AND. Use this when you want different filter behavior for backfill vs. incremental reads.\n",
                                                     "x-go-type-skip-optional-pointer": true,
@@ -23608,7 +23608,7 @@
                                                   }
                                                 }
                                               },
-                                              "filter": {
+                                              "fieldFilters": {
                                                 "type": "array",
                                                 "description": "Filters to apply when reading records during incremental reads and backfill. Multiple conditions are joined by AND. Each field can only have one condition.\n",
                                                 "x-go-type-skip-optional-pointer": true,
@@ -23818,7 +23818,7 @@
                                                           }
                                                         }
                                                       },
-                                                      "filter": {
+                                                      "fieldFilters": {
                                                         "type": "array",
                                                         "description": "Filters to apply only during backfill. Multiple conditions are joined by AND. Use this when you want different filter behavior for backfill vs. incremental reads.\n",
                                                         "x-go-type-skip-optional-pointer": true,
@@ -23853,7 +23853,7 @@
                                                       }
                                                     }
                                                   },
-                                                  "filter": {
+                                                  "fieldFilters": {
                                                     "type": "array",
                                                     "description": "Filters to apply when reading records during incremental reads and backfill. Multiple conditions are joined by AND. Each field can only have one condition.\n",
                                                     "x-go-type-skip-optional-pointer": true,
@@ -25274,13 +25274,13 @@
                           "type": "string",
                           "description": "The time the group was created.",
                           "format": "date-time",
-                          "example": "2023-07-13T21:34:44.816Z"
+                          "example": "2023-07-13T21:34:44.816354Z"
                         },
                         "updateTime": {
                           "type": "string",
                           "description": "The time the group was last updated.",
                           "format": "date-time",
-                          "example": "2023-07-13T21:34:44.816Z"
+                          "example": "2023-07-13T21:34:44.816354Z"
                         }
                       }
                     },
@@ -25421,13 +25421,13 @@
                               "type": "string",
                               "description": "The time the group was created.",
                               "format": "date-time",
-                              "example": "2023-07-13T21:34:44.816Z"
+                              "example": "2023-07-13T21:34:44.816354Z"
                             },
                             "updateTime": {
                               "type": "string",
                               "description": "The time the group was last updated.",
                               "format": "date-time",
-                              "example": "2023-07-13T21:34:44.816Z"
+                              "example": "2023-07-13T21:34:44.816354Z"
                             }
                           }
                         },
@@ -25460,13 +25460,13 @@
                               "type": "string",
                               "description": "The time the consumer was created.",
                               "format": "date-time",
-                              "example": "2023-07-13T21:34:44.816Z"
+                              "example": "2023-07-13T21:34:44.816354Z"
                             },
                             "updateTime": {
                               "type": "string",
                               "description": "The time the consumer was last updated.",
                               "format": "date-time",
-                              "example": "2023-07-13T21:34:44.816Z"
+                              "example": "2023-07-13T21:34:44.816354Z"
                             }
                           }
                         },
@@ -25484,13 +25484,13 @@
                           "type": "string",
                           "description": "The time the connection was created.",
                           "format": "date-time",
-                          "example": "2023-07-13T21:34:44.816Z"
+                          "example": "2023-07-13T21:34:44.816354Z"
                         },
                         "updateTime": {
                           "type": "string",
                           "description": "The time the connection was last updated.",
                           "format": "date-time",
-                          "example": "2023-07-13T21:34:44.816Z"
+                          "example": "2023-07-13T21:34:44.816354Z"
                         },
                         "authScheme": {
                           "type": "string",
@@ -25841,7 +25841,7 @@
                                                   }
                                                 }
                                               },
-                                              "filter": {
+                                              "fieldFilters": {
                                                 "type": "array",
                                                 "description": "Filters to apply only during backfill. Multiple conditions are joined by AND. Use this when you want different filter behavior for backfill vs. incremental reads.\n",
                                                 "x-go-type-skip-optional-pointer": true,
@@ -25876,7 +25876,7 @@
                                               }
                                             }
                                           },
-                                          "filter": {
+                                          "fieldFilters": {
                                             "type": "array",
                                             "description": "Filters to apply when reading records during incremental reads and backfill. Multiple conditions are joined by AND. Each field can only have one condition.\n",
                                             "x-go-type-skip-optional-pointer": true,
@@ -26271,7 +26271,7 @@
                                                       }
                                                     }
                                                   },
-                                                  "filter": {
+                                                  "fieldFilters": {
                                                     "type": "array",
                                                     "description": "Filters to apply only during backfill. Multiple conditions are joined by AND. Use this when you want different filter behavior for backfill vs. incremental reads.\n",
                                                     "x-go-type-skip-optional-pointer": true,
@@ -26306,7 +26306,7 @@
                                                   }
                                                 }
                                               },
-                                              "filter": {
+                                              "fieldFilters": {
                                                 "type": "array",
                                                 "description": "Filters to apply when reading records during incremental reads and backfill. Multiple conditions are joined by AND. Each field can only have one condition.\n",
                                                 "x-go-type-skip-optional-pointer": true,
@@ -26516,7 +26516,7 @@
                                                           }
                                                         }
                                                       },
-                                                      "filter": {
+                                                      "fieldFilters": {
                                                         "type": "array",
                                                         "description": "Filters to apply only during backfill. Multiple conditions are joined by AND. Use this when you want different filter behavior for backfill vs. incremental reads.\n",
                                                         "x-go-type-skip-optional-pointer": true,
@@ -26551,7 +26551,7 @@
                                                       }
                                                     }
                                                   },
-                                                  "filter": {
+                                                  "fieldFilters": {
                                                     "type": "array",
                                                     "description": "Filters to apply when reading records during incremental reads and backfill. Multiple conditions are joined by AND. Each field can only have one condition.\n",
                                                     "x-go-type-skip-optional-pointer": true,
@@ -28493,13 +28493,13 @@
                             "type": "string",
                             "description": "The time the group was created.",
                             "format": "date-time",
-                            "example": "2023-07-13T21:34:44.816Z"
+                            "example": "2023-07-13T21:34:44.816354Z"
                           },
                           "updateTime": {
                             "type": "string",
                             "description": "The time the group was last updated.",
                             "format": "date-time",
-                            "example": "2023-07-13T21:34:44.816Z"
+                            "example": "2023-07-13T21:34:44.816354Z"
                           }
                         }
                       },
@@ -28640,13 +28640,13 @@
                                 "type": "string",
                                 "description": "The time the group was created.",
                                 "format": "date-time",
-                                "example": "2023-07-13T21:34:44.816Z"
+                                "example": "2023-07-13T21:34:44.816354Z"
                               },
                               "updateTime": {
                                 "type": "string",
                                 "description": "The time the group was last updated.",
                                 "format": "date-time",
-                                "example": "2023-07-13T21:34:44.816Z"
+                                "example": "2023-07-13T21:34:44.816354Z"
                               }
                             }
                           },
@@ -28679,13 +28679,13 @@
                                 "type": "string",
                                 "description": "The time the consumer was created.",
                                 "format": "date-time",
-                                "example": "2023-07-13T21:34:44.816Z"
+                                "example": "2023-07-13T21:34:44.816354Z"
                               },
                               "updateTime": {
                                 "type": "string",
                                 "description": "The time the consumer was last updated.",
                                 "format": "date-time",
-                                "example": "2023-07-13T21:34:44.816Z"
+                                "example": "2023-07-13T21:34:44.816354Z"
                               }
                             }
                           },
@@ -28703,13 +28703,13 @@
                             "type": "string",
                             "description": "The time the connection was created.",
                             "format": "date-time",
-                            "example": "2023-07-13T21:34:44.816Z"
+                            "example": "2023-07-13T21:34:44.816354Z"
                           },
                           "updateTime": {
                             "type": "string",
                             "description": "The time the connection was last updated.",
                             "format": "date-time",
-                            "example": "2023-07-13T21:34:44.816Z"
+                            "example": "2023-07-13T21:34:44.816354Z"
                           },
                           "authScheme": {
                             "type": "string",
@@ -29060,7 +29060,7 @@
                                                     }
                                                   }
                                                 },
-                                                "filter": {
+                                                "fieldFilters": {
                                                   "type": "array",
                                                   "description": "Filters to apply only during backfill. Multiple conditions are joined by AND. Use this when you want different filter behavior for backfill vs. incremental reads.\n",
                                                   "x-go-type-skip-optional-pointer": true,
@@ -29095,7 +29095,7 @@
                                                 }
                                               }
                                             },
-                                            "filter": {
+                                            "fieldFilters": {
                                               "type": "array",
                                               "description": "Filters to apply when reading records during incremental reads and backfill. Multiple conditions are joined by AND. Each field can only have one condition.\n",
                                               "x-go-type-skip-optional-pointer": true,
@@ -29490,7 +29490,7 @@
                                                         }
                                                       }
                                                     },
-                                                    "filter": {
+                                                    "fieldFilters": {
                                                       "type": "array",
                                                       "description": "Filters to apply only during backfill. Multiple conditions are joined by AND. Use this when you want different filter behavior for backfill vs. incremental reads.\n",
                                                       "x-go-type-skip-optional-pointer": true,
@@ -29525,7 +29525,7 @@
                                                     }
                                                   }
                                                 },
-                                                "filter": {
+                                                "fieldFilters": {
                                                   "type": "array",
                                                   "description": "Filters to apply when reading records during incremental reads and backfill. Multiple conditions are joined by AND. Each field can only have one condition.\n",
                                                   "x-go-type-skip-optional-pointer": true,
@@ -29735,7 +29735,7 @@
                                                             }
                                                           }
                                                         },
-                                                        "filter": {
+                                                        "fieldFilters": {
                                                           "type": "array",
                                                           "description": "Filters to apply only during backfill. Multiple conditions are joined by AND. Use this when you want different filter behavior for backfill vs. incremental reads.\n",
                                                           "x-go-type-skip-optional-pointer": true,
@@ -29770,7 +29770,7 @@
                                                         }
                                                       }
                                                     },
-                                                    "filter": {
+                                                    "fieldFilters": {
                                                       "type": "array",
                                                       "description": "Filters to apply when reading records during incremental reads and backfill. Multiple conditions are joined by AND. Each field can only have one condition.\n",
                                                       "x-go-type-skip-optional-pointer": true,
@@ -33328,7 +33328,7 @@
                             "type": "string",
                             "description": "The time the operation was created.",
                             "format": "date-time",
-                            "example": "2023-07-13T21:34:44.816Z"
+                            "example": "2023-07-13T21:34:44.816354Z"
                           }
                         }
                       }
@@ -35009,7 +35009,7 @@
                       "type": "string",
                       "description": "The time the operation was created.",
                       "format": "date-time",
-                      "example": "2023-07-13T21:34:44.816Z"
+                      "example": "2023-07-13T21:34:44.816354Z"
                     }
                   }
                 },
@@ -35281,7 +35281,7 @@
                       "timestamp": {
                         "type": "string",
                         "description": "The time the log was created.",
-                        "example": "2023-07-13T21:34:44.816Z"
+                        "example": "2023-07-13T21:34:44.816354Z"
                       },
                       "message": {
                         "type": "object",
@@ -42106,13 +42106,13 @@
                             "type": "string",
                             "description": "The time the group was created.",
                             "format": "date-time",
-                            "example": "2023-07-13T21:34:44.816Z"
+                            "example": "2023-07-13T21:34:44.816354Z"
                           },
                           "updateTime": {
                             "type": "string",
                             "description": "The time the group was last updated.",
                             "format": "date-time",
-                            "example": "2023-07-13T21:34:44.816Z"
+                            "example": "2023-07-13T21:34:44.816354Z"
                           }
                         }
                       },
@@ -42145,13 +42145,13 @@
                             "type": "string",
                             "description": "The time the consumer was created.",
                             "format": "date-time",
-                            "example": "2023-07-13T21:34:44.816Z"
+                            "example": "2023-07-13T21:34:44.816354Z"
                           },
                           "updateTime": {
                             "type": "string",
                             "description": "The time the consumer was last updated.",
                             "format": "date-time",
-                            "example": "2023-07-13T21:34:44.816Z"
+                            "example": "2023-07-13T21:34:44.816354Z"
                           }
                         }
                       },
@@ -42169,13 +42169,13 @@
                         "type": "string",
                         "description": "The time the connection was created.",
                         "format": "date-time",
-                        "example": "2023-07-13T21:34:44.816Z"
+                        "example": "2023-07-13T21:34:44.816354Z"
                       },
                       "updateTime": {
                         "type": "string",
                         "description": "The time the connection was last updated.",
                         "format": "date-time",
-                        "example": "2023-07-13T21:34:44.816Z"
+                        "example": "2023-07-13T21:34:44.816354Z"
                       },
                       "authScheme": {
                         "type": "string",
@@ -43136,13 +43136,13 @@
                           "type": "string",
                           "description": "The time the group was created.",
                           "format": "date-time",
-                          "example": "2023-07-13T21:34:44.816Z"
+                          "example": "2023-07-13T21:34:44.816354Z"
                         },
                         "updateTime": {
                           "type": "string",
                           "description": "The time the group was last updated.",
                           "format": "date-time",
-                          "example": "2023-07-13T21:34:44.816Z"
+                          "example": "2023-07-13T21:34:44.816354Z"
                         }
                       }
                     },
@@ -43175,13 +43175,13 @@
                           "type": "string",
                           "description": "The time the consumer was created.",
                           "format": "date-time",
-                          "example": "2023-07-13T21:34:44.816Z"
+                          "example": "2023-07-13T21:34:44.816354Z"
                         },
                         "updateTime": {
                           "type": "string",
                           "description": "The time the consumer was last updated.",
                           "format": "date-time",
-                          "example": "2023-07-13T21:34:44.816Z"
+                          "example": "2023-07-13T21:34:44.816354Z"
                         }
                       }
                     },
@@ -43199,13 +43199,13 @@
                       "type": "string",
                       "description": "The time the connection was created.",
                       "format": "date-time",
-                      "example": "2023-07-13T21:34:44.816Z"
+                      "example": "2023-07-13T21:34:44.816354Z"
                     },
                     "updateTime": {
                       "type": "string",
                       "description": "The time the connection was last updated.",
                       "format": "date-time",
-                      "example": "2023-07-13T21:34:44.816Z"
+                      "example": "2023-07-13T21:34:44.816354Z"
                     },
                     "authScheme": {
                       "type": "string",
@@ -44297,13 +44297,13 @@
                           "type": "string",
                           "description": "The time the group was created.",
                           "format": "date-time",
-                          "example": "2023-07-13T21:34:44.816Z"
+                          "example": "2023-07-13T21:34:44.816354Z"
                         },
                         "updateTime": {
                           "type": "string",
                           "description": "The time the group was last updated.",
                           "format": "date-time",
-                          "example": "2023-07-13T21:34:44.816Z"
+                          "example": "2023-07-13T21:34:44.816354Z"
                         }
                       }
                     },
@@ -44336,13 +44336,13 @@
                           "type": "string",
                           "description": "The time the consumer was created.",
                           "format": "date-time",
-                          "example": "2023-07-13T21:34:44.816Z"
+                          "example": "2023-07-13T21:34:44.816354Z"
                         },
                         "updateTime": {
                           "type": "string",
                           "description": "The time the consumer was last updated.",
                           "format": "date-time",
-                          "example": "2023-07-13T21:34:44.816Z"
+                          "example": "2023-07-13T21:34:44.816354Z"
                         }
                       }
                     },
@@ -44360,13 +44360,13 @@
                       "type": "string",
                       "description": "The time the connection was created.",
                       "format": "date-time",
-                      "example": "2023-07-13T21:34:44.816Z"
+                      "example": "2023-07-13T21:34:44.816354Z"
                     },
                     "updateTime": {
                       "type": "string",
                       "description": "The time the connection was last updated.",
                       "format": "date-time",
-                      "example": "2023-07-13T21:34:44.816Z"
+                      "example": "2023-07-13T21:34:44.816354Z"
                     },
                     "authScheme": {
                       "type": "string",
@@ -45389,13 +45389,13 @@
                           "type": "string",
                           "description": "The time the group was created.",
                           "format": "date-time",
-                          "example": "2023-07-13T21:34:44.816Z"
+                          "example": "2023-07-13T21:34:44.816354Z"
                         },
                         "updateTime": {
                           "type": "string",
                           "description": "The time the group was last updated.",
                           "format": "date-time",
-                          "example": "2023-07-13T21:34:44.816Z"
+                          "example": "2023-07-13T21:34:44.816354Z"
                         }
                       }
                     },
@@ -45428,13 +45428,13 @@
                           "type": "string",
                           "description": "The time the consumer was created.",
                           "format": "date-time",
-                          "example": "2023-07-13T21:34:44.816Z"
+                          "example": "2023-07-13T21:34:44.816354Z"
                         },
                         "updateTime": {
                           "type": "string",
                           "description": "The time the consumer was last updated.",
                           "format": "date-time",
-                          "example": "2023-07-13T21:34:44.816Z"
+                          "example": "2023-07-13T21:34:44.816354Z"
                         }
                       }
                     },
@@ -45452,13 +45452,13 @@
                       "type": "string",
                       "description": "The time the connection was created.",
                       "format": "date-time",
-                      "example": "2023-07-13T21:34:44.816Z"
+                      "example": "2023-07-13T21:34:44.816354Z"
                     },
                     "updateTime": {
                       "type": "string",
                       "description": "The time the connection was last updated.",
                       "format": "date-time",
-                      "example": "2023-07-13T21:34:44.816Z"
+                      "example": "2023-07-13T21:34:44.816354Z"
                     },
                     "authScheme": {
                       "type": "string",
@@ -67067,13 +67067,13 @@
                 "type": "string",
                 "description": "The time the group was created.",
                 "format": "date-time",
-                "example": "2023-07-13T21:34:44.816Z"
+                "example": "2023-07-13T21:34:44.816354Z"
               },
               "updateTime": {
                 "type": "string",
                 "description": "The time the group was last updated.",
                 "format": "date-time",
-                "example": "2023-07-13T21:34:44.816Z"
+                "example": "2023-07-13T21:34:44.816354Z"
               }
             }
           },
@@ -67214,13 +67214,13 @@
                     "type": "string",
                     "description": "The time the group was created.",
                     "format": "date-time",
-                    "example": "2023-07-13T21:34:44.816Z"
+                    "example": "2023-07-13T21:34:44.816354Z"
                   },
                   "updateTime": {
                     "type": "string",
                     "description": "The time the group was last updated.",
                     "format": "date-time",
-                    "example": "2023-07-13T21:34:44.816Z"
+                    "example": "2023-07-13T21:34:44.816354Z"
                   }
                 }
               },
@@ -67253,13 +67253,13 @@
                     "type": "string",
                     "description": "The time the consumer was created.",
                     "format": "date-time",
-                    "example": "2023-07-13T21:34:44.816Z"
+                    "example": "2023-07-13T21:34:44.816354Z"
                   },
                   "updateTime": {
                     "type": "string",
                     "description": "The time the consumer was last updated.",
                     "format": "date-time",
-                    "example": "2023-07-13T21:34:44.816Z"
+                    "example": "2023-07-13T21:34:44.816354Z"
                   }
                 }
               },
@@ -67277,13 +67277,13 @@
                 "type": "string",
                 "description": "The time the connection was created.",
                 "format": "date-time",
-                "example": "2023-07-13T21:34:44.816Z"
+                "example": "2023-07-13T21:34:44.816354Z"
               },
               "updateTime": {
                 "type": "string",
                 "description": "The time the connection was last updated.",
                 "format": "date-time",
-                "example": "2023-07-13T21:34:44.816Z"
+                "example": "2023-07-13T21:34:44.816354Z"
               },
               "authScheme": {
                 "type": "string",
@@ -67634,7 +67634,7 @@
                                         }
                                       }
                                     },
-                                    "filter": {
+                                    "fieldFilters": {
                                       "type": "array",
                                       "description": "Filters to apply only during backfill. Multiple conditions are joined by AND. Use this when you want different filter behavior for backfill vs. incremental reads.\n",
                                       "x-go-type-skip-optional-pointer": true,
@@ -67669,7 +67669,7 @@
                                     }
                                   }
                                 },
-                                "filter": {
+                                "fieldFilters": {
                                   "type": "array",
                                   "description": "Filters to apply when reading records during incremental reads and backfill. Multiple conditions are joined by AND. Each field can only have one condition.\n",
                                   "x-go-type-skip-optional-pointer": true,
@@ -68064,7 +68064,7 @@
                                             }
                                           }
                                         },
-                                        "filter": {
+                                        "fieldFilters": {
                                           "type": "array",
                                           "description": "Filters to apply only during backfill. Multiple conditions are joined by AND. Use this when you want different filter behavior for backfill vs. incremental reads.\n",
                                           "x-go-type-skip-optional-pointer": true,
@@ -68099,7 +68099,7 @@
                                         }
                                       }
                                     },
-                                    "filter": {
+                                    "fieldFilters": {
                                       "type": "array",
                                       "description": "Filters to apply when reading records during incremental reads and backfill. Multiple conditions are joined by AND. Each field can only have one condition.\n",
                                       "x-go-type-skip-optional-pointer": true,
@@ -68309,7 +68309,7 @@
                                                 }
                                               }
                                             },
-                                            "filter": {
+                                            "fieldFilters": {
                                               "type": "array",
                                               "description": "Filters to apply only during backfill. Multiple conditions are joined by AND. Use this when you want different filter behavior for backfill vs. incremental reads.\n",
                                               "x-go-type-skip-optional-pointer": true,
@@ -68344,7 +68344,7 @@
                                             }
                                           }
                                         },
-                                        "filter": {
+                                        "fieldFilters": {
                                           "type": "array",
                                           "description": "Filters to apply when reading records during incremental reads and backfill. Multiple conditions are joined by AND. Each field can only have one condition.\n",
                                           "x-go-type-skip-optional-pointer": true,
@@ -69274,7 +69274,7 @@
                                     }
                                   }
                                 },
-                                "filter": {
+                                "fieldFilters": {
                                   "type": "array",
                                   "description": "Filters to apply only during backfill. Multiple conditions are joined by AND. Use this when you want different filter behavior for backfill vs. incremental reads.\n",
                                   "x-go-type-skip-optional-pointer": true,
@@ -69309,7 +69309,7 @@
                                 }
                               }
                             },
-                            "filter": {
+                            "fieldFilters": {
                               "type": "array",
                               "description": "Filters to apply when reading records during incremental reads and backfill. Multiple conditions are joined by AND. Each field can only have one condition.\n",
                               "x-go-type-skip-optional-pointer": true,
@@ -69704,7 +69704,7 @@
                                         }
                                       }
                                     },
-                                    "filter": {
+                                    "fieldFilters": {
                                       "type": "array",
                                       "description": "Filters to apply only during backfill. Multiple conditions are joined by AND. Use this when you want different filter behavior for backfill vs. incremental reads.\n",
                                       "x-go-type-skip-optional-pointer": true,
@@ -69739,7 +69739,7 @@
                                     }
                                   }
                                 },
-                                "filter": {
+                                "fieldFilters": {
                                   "type": "array",
                                   "description": "Filters to apply when reading records during incremental reads and backfill. Multiple conditions are joined by AND. Each field can only have one condition.\n",
                                   "x-go-type-skip-optional-pointer": true,
@@ -69949,7 +69949,7 @@
                                             }
                                           }
                                         },
-                                        "filter": {
+                                        "fieldFilters": {
                                           "type": "array",
                                           "description": "Filters to apply only during backfill. Multiple conditions are joined by AND. Use this when you want different filter behavior for backfill vs. incremental reads.\n",
                                           "x-go-type-skip-optional-pointer": true,
@@ -69984,7 +69984,7 @@
                                         }
                                       }
                                     },
-                                    "filter": {
+                                    "fieldFilters": {
                                       "type": "array",
                                       "description": "Filters to apply when reading records during incremental reads and backfill. Multiple conditions are joined by AND. Each field can only have one condition.\n",
                                       "x-go-type-skip-optional-pointer": true,
@@ -70788,13 +70788,13 @@
                 "type": "string",
                 "description": "The time the group was created.",
                 "format": "date-time",
-                "example": "2023-07-13T21:34:44.816Z"
+                "example": "2023-07-13T21:34:44.816354Z"
               },
               "updateTime": {
                 "type": "string",
                 "description": "The time the group was last updated.",
                 "format": "date-time",
-                "example": "2023-07-13T21:34:44.816Z"
+                "example": "2023-07-13T21:34:44.816354Z"
               }
             }
           },
@@ -70827,13 +70827,13 @@
                 "type": "string",
                 "description": "The time the consumer was created.",
                 "format": "date-time",
-                "example": "2023-07-13T21:34:44.816Z"
+                "example": "2023-07-13T21:34:44.816354Z"
               },
               "updateTime": {
                 "type": "string",
                 "description": "The time the consumer was last updated.",
                 "format": "date-time",
-                "example": "2023-07-13T21:34:44.816Z"
+                "example": "2023-07-13T21:34:44.816354Z"
               }
             }
           },
@@ -70851,13 +70851,13 @@
             "type": "string",
             "description": "The time the connection was created.",
             "format": "date-time",
-            "example": "2023-07-13T21:34:44.816Z"
+            "example": "2023-07-13T21:34:44.816354Z"
           },
           "updateTime": {
             "type": "string",
             "description": "The time the connection was last updated.",
             "format": "date-time",
-            "example": "2023-07-13T21:34:44.816Z"
+            "example": "2023-07-13T21:34:44.816354Z"
           },
           "authScheme": {
             "type": "string",
@@ -71789,13 +71789,13 @@
             "type": "string",
             "description": "The time the group was created.",
             "format": "date-time",
-            "example": "2023-07-13T21:34:44.816Z"
+            "example": "2023-07-13T21:34:44.816354Z"
           },
           "updateTime": {
             "type": "string",
             "description": "The time the group was last updated.",
             "format": "date-time",
-            "example": "2023-07-13T21:34:44.816Z"
+            "example": "2023-07-13T21:34:44.816354Z"
           }
         }
       },
@@ -71828,13 +71828,13 @@
             "type": "string",
             "description": "The time the consumer was created.",
             "format": "date-time",
-            "example": "2023-07-13T21:34:44.816Z"
+            "example": "2023-07-13T21:34:44.816354Z"
           },
           "updateTime": {
             "type": "string",
             "description": "The time the consumer was last updated.",
             "format": "date-time",
-            "example": "2023-07-13T21:34:44.816Z"
+            "example": "2023-07-13T21:34:44.816354Z"
           }
         }
       },
@@ -71961,7 +71961,7 @@
             "type": "string",
             "description": "The time the operation was created.",
             "format": "date-time",
-            "example": "2023-07-13T21:34:44.816Z"
+            "example": "2023-07-13T21:34:44.816354Z"
           }
         }
       },
@@ -72021,7 +72021,7 @@
           "timestamp": {
             "type": "string",
             "description": "The time the log was created.",
-            "example": "2023-07-13T21:34:44.816Z"
+            "example": "2023-07-13T21:34:44.816354Z"
           },
           "message": {
             "type": "object",

--- a/src/provider-guides/dynamicsCRM.mdx
+++ b/src/provider-guides/dynamicsCRM.mdx
@@ -13,20 +13,28 @@ This connector supports:
 
 ### Supported Objects
 
-The Microsoft's DynamicsCRM connector supports reading from and writing to all the available objects in the Microsoft Dynamics 365 Sales module, which totals to more than 1000 objects and include:
-- catalog ([read-only fields](https://learn.microsoft.com/en-us/power-apps/developer/data-platform/reference/entities/catalog#read-only-columnsattributes), [write-only fields](https://learn.microsoft.com/en-us/power-apps/developer/data-platform/reference/entities/catalog#writable-columnsattributes))
-- contact ([read-only fields](https://learn.microsoft.com/en-us/dynamics365/sales/developer/entities/contact#read-only-columnsattributes), [writable fields](https://learn.microsoft.com/en-us/dynamics365/sales/developer/entities/contact#writable-columnsattributes))
-- discount ([read-only fields](https://learn.microsoft.com/en-us/dynamics365/sales/developer/entities/discount#read-only-columnsattributes), [writable fields](https://learn.microsoft.com/en-us/dynamics365/sales/developer/entities/discount#writable-columnsattributes))
-- goal ([read-only fields](https://learn.microsoft.com/en-us/dynamics365/sales/developer/entities/goal#read-only-columnsattributes), [writable fields](https://learn.microsoft.com/en-us/dynamics365/sales/developer/entities/goal#writable-columnsattributes))
-- lead ([read-only fields](https://learn.microsoft.com/en-us/dynamics365/sales/developer/entities/lead#read-only-columnsattributes), [writable fields](https://learn.microsoft.com/en-us/dynamics365/sales/developer/entities/lead#writable-columnsattributes))
-- list (Marketing list [read-only fields](https://learn.microsoft.com/en-us/dynamics365/sales/developer/entities/list#read-only-columnsattributes), [writable fields](https://learn.microsoft.com/en-us/dynamics365/sales/developer/entities/list#writable-columnsattributes))
-- msdyn_aitemplate ([read-only fields](https://learn.microsoft.com/en-us/power-apps/developer/data-platform/reference/entities/msdyn_aitemplate#read-only-columnsattributes), [write-only fields](https://learn.microsoft.com/en-us/power-apps/developer/data-platform/reference/entities/msdyn_aitemplate#writable-columnsattributes))
-- opportunity ([read-only fields](https://learn.microsoft.com/en-us/dynamics365/sales/developer/entities/opportunity#read-only-columnsattributes), [write-only fields](https://learn.microsoft.com/en-us/dynamics365/sales/developer/entities/opportunity#writable-columnsattributes))
-- product ([read-only fields](https://learn.microsoft.com/en-us/dynamics365/sales/developer/entities/product#read-only-columnsattributes), [write-only fields](https://learn.microsoft.com/en-us/dynamics365/sales/developer/entities/product#writable-columnsattributes))
-- quote ([read-only fields](https://learn.microsoft.com/en-us/dynamics365/sales/developer/entities/quote#read-only-columnsattributes), [write-only fields](https://learn.microsoft.com/en-us/dynamics365/sales/developer/entities/quote#writable-columnsattributes))
-- salesorder ([read-only fields](https://learn.microsoft.com/en-us/dynamics365/sales/developer/entities/salesorder#read-only-columnsattributes), [write-only fields](https://learn.microsoft.com/en-us/dynamics365/sales/developer/entities/salesorder#writable-columnsattributes))
-- All the other objects in the [Dynamics Sales tables reference](https://learn.microsoft.com/en-us/dynamics365/sales/developer/about-entity-reference)
-- As well as objects in the [Dataverse tables reference](https://learn.microsoft.com/en-us/power-apps/developer/data-platform/reference/about-entity-reference)
+The Microsoft Dynamics 365 CRM connector supports reading from and writing to all available objects in the
+Microsoft Dynamics 365 Sales, Customer Service, and Field Service modules,
+which together contain more than 1000 tables, some examples include:
+- [catalogs](https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/reference/catalog?view=dataverse-latest) ([read-only fields](https://learn.microsoft.com/en-us/power-apps/developer/data-platform/reference/entities/catalog#read-only-columnsattributes), [write-only fields](https://learn.microsoft.com/en-us/power-apps/developer/data-platform/reference/entities/catalog#writable-columnsattributes))
+- [contacts](https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/reference/contact?view=dataverse-latest) ([read-only fields](https://learn.microsoft.com/en-us/dynamics365/sales/developer/entities/contact#read-only-columnsattributes), [writable fields](https://learn.microsoft.com/en-us/dynamics365/sales/developer/entities/contact#writable-columnsattributes))
+- discounts ([read-only fields](https://learn.microsoft.com/en-us/dynamics365/sales/developer/entities/discount#read-only-columnsattributes), [writable fields](https://learn.microsoft.com/en-us/dynamics365/sales/developer/entities/discount#writable-columnsattributes))
+- [goal](https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/reference/goal?view=dataverse-latest) ([read-only fields](https://learn.microsoft.com/en-us/dynamics365/sales/developer/entities/goal#read-only-columnsattributes), [writable fields](https://learn.microsoft.com/en-us/dynamics365/sales/developer/entities/goal#writable-columnsattributes))
+- leads ([read-only fields](https://learn.microsoft.com/en-us/dynamics365/sales/developer/entities/lead#read-only-columnsattributes), [writable fields](https://learn.microsoft.com/en-us/dynamics365/sales/developer/entities/lead#writable-columnsattributes))
+- lists (Marketing list [read-only fields](https://learn.microsoft.com/en-us/dynamics365/sales/developer/entities/list#read-only-columnsattributes), [writable fields](https://learn.microsoft.com/en-us/dynamics365/sales/developer/entities/list#writable-columnsattributes))
+- [msdyn_aitemplates](https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/reference/msdyn_aitemplate?view=dataverse-latest) ([read-only fields](https://learn.microsoft.com/en-us/power-apps/developer/data-platform/reference/entities/msdyn_aitemplate#read-only-columnsattributes), [write-only fields](https://learn.microsoft.com/en-us/power-apps/developer/data-platform/reference/entities/msdyn_aitemplate#writable-columnsattributes))
+- opportunities ([read-only fields](https://learn.microsoft.com/en-us/dynamics365/sales/developer/entities/opportunity#read-only-columnsattributes), [write-only fields](https://learn.microsoft.com/en-us/dynamics365/sales/developer/entities/opportunity#writable-columnsattributes))
+- products ([read-only fields](https://learn.microsoft.com/en-us/dynamics365/sales/developer/entities/product#read-only-columnsattributes), [write-only fields](https://learn.microsoft.com/en-us/dynamics365/sales/developer/entities/product#writable-columnsattributes))
+- quotes ([read-only fields](https://learn.microsoft.com/en-us/dynamics365/sales/developer/entities/quote#read-only-columnsattributes), [write-only fields](https://learn.microsoft.com/en-us/dynamics365/sales/developer/entities/quote#writable-columnsattributes))
+- salesorders ([read-only fields](https://learn.microsoft.com/en-us/dynamics365/sales/developer/entities/salesorder#read-only-columnsattributes), [write-only fields](https://learn.microsoft.com/en-us/dynamics365/sales/developer/entities/salesorder#writable-columnsattributes))
+
+Product‑specific objects are supported:
+- Objects in the [Dynamics 365 Sales tables reference](https://learn.microsoft.com/en-us/dynamics365/sales/developer/about-entity-reference)
+- Objects in the [Dynamics 365 Customer Service tables reference](https://learn.microsoft.com/en-us/dynamics365/customer-service/develop/reference/about-entity-reference)
+- Objects in the [Dynamics 365 Field Service tables reference](https://learn.microsoft.com/en-us/dynamics365/field-service/developer/reference/about-entity-reference)
+
+In addition, the connector supports all the objects in the [Dataverse tables reference](https://learn.microsoft.com/en-us/power-apps/developer/data-platform/reference/about-entity-reference),
+which are available in every Dynamics 365 environment regardless of the specific app you have licensed, you can think of them as core out-of-the-box objects.
 
 ### Example Integration
 


### PR DESCRIPTION
## Description

Object names are pluralized.

There is a mixture of objects from core Dynamics and from flavors like Sales (part of CRM).
The documentation for both differs, for the core objects I was able to find docs with URL endpoints and for the CRM there is not such thing.

I bet [Field Service](https://learn.microsoft.com/en-us/dynamics365/field-service/) must be supported by this connector. I updated a slab doc on dynamics 365.

Therefore, I restructured the last part of the docs to better explain the relationship of Products and the Entities that you get by buying that product.

## Screenshot

<img width="761" height="834" alt="image" src="https://github.com/user-attachments/assets/028ed4d1-2bd5-486e-a113-e06d449b4b83" />
