### PR TITLE
[ENG-3705] docs: add fieldFilters documentation to read actions

### DIFF
--- a/src/provider-guides/hubspot.mdx
+++ b/src/provider-guides/hubspot.mdx
@@ -8,7 +8,7 @@ title: "HubSpot"
 
 The Hubspot connector supports:
 
-- [Read Actions](/read-actions), including full historic backfill and incremental reads.
+- [Read Actions](/read-actions), including full historic backfill, incremental reads, and filters.
 - [Subscribe Actions](/subscribe-actions). Please note that [special set up](/subscribe-actions#special-set-up-for-hubspot) is needed for HubSpot.
 - [Write Actions](/write-actions), including Bulk Write and Delete.
 - [Proxy Actions](/proxy-actions), using the base URL `https://api.hubapi.com`.

--- a/src/provider-guides/salesforce.mdx
+++ b/src/provider-guides/salesforce.mdx
@@ -14,7 +14,7 @@ This connector has two modules, with CRM as the default.
 
 The **CRM** module supports:
 - [Proxy Actions](/proxy-actions), using the base URL `https://{{.workspace}}.my.salesforce.com`.
-- [Read Actions](/read-actions), including full historic backfill and incremental read.
+- [Read Actions](/read-actions), including full historic backfill, incremental read, and filters.
 - [Subscribe Actions](/subscribe-actions).
 - [Write Actions](/write-actions), including Bulk Write and Delete.
 

--- a/src/read-actions.mdx
+++ b/src/read-actions.mdx
@@ -141,7 +141,7 @@ The API returns:
 
 ## Filtering records
 
-You can filter which records are returned by a read action by setting `fieldFilters` in the [installation config](/reference/installation/create-an-installation). Filters are applied server-side by the SaaS provider, so only matching records are read and delivered to your destination.
+You can filter which records are returned by a read action by setting `fieldFilters` in the [installation config](/reference/installation/create-a-new-installation). Filters are applied server-side by the SaaS provider, so only matching records are read and delivered to your destination.
 
 Each filter specifies a field name, an operator, and a value. Currently, only the `eq` (equals) operator is supported. Multiple filters are joined with AND logic, and each field can only have one condition.
 

--- a/src/read-actions.mdx
+++ b/src/read-actions.mdx
@@ -139,6 +139,79 @@ The API returns:
 - **createTime** — When the backfill started
 - **updateTime** — When progress was last updated
 
+## Filtering records
+
+You can filter which records are returned by a read action by setting `fieldFilters` in the [installation config](/reference/installation/create-an-installation). Filters are applied server-side by the SaaS provider, so only matching records are read and delivered to your destination.
+
+Each filter specifies a field name, an operator, and a value. Currently, only the `eq` (equals) operator is supported. Multiple filters are joined with AND logic, and each field can only have one condition.
+
+### Filter all reads
+
+To filter both incremental reads and backfill, set `fieldFilters` on the object in the installation config:
+
+```json
+{
+  "read": {
+    "objects": {
+      "contacts": {
+        "objectName": "contacts",
+        "selectedFields": { "email": true, "firstname": true, "lastname": true },
+        "backfill": {
+          "defaultPeriod": { "fullHistory": true }
+        },
+        "fieldFilters": [
+          { "fieldName": "firstname", "operator": "eq", "value": "Brian" }
+        ]
+      }
+    }
+  }
+}
+```
+
+In this example, only contacts whose `firstname` equals "Brian" will be returned during both scheduled reads and backfill.
+
+### Filter backfill only
+
+If you want different filter behavior for backfill vs. incremental reads, you can set `fieldFilters` inside the `backfill` object. When set, this overrides the object-level `fieldFilters` during backfill.
+
+```json
+{
+  "read": {
+    "objects": {
+      "contacts": {
+        "objectName": "contacts",
+        "selectedFields": { "email": true, "firstname": true, "lastname": true },
+        "fieldFilters": [
+          { "fieldName": "status", "operator": "eq", "value": "active" }
+        ],
+        "backfill": {
+          "defaultPeriod": { "fullHistory": true },
+          "fieldFilters": [
+            { "fieldName": "firstname", "operator": "eq", "value": "Brian" }
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+In this example, the backfill will only return contacts whose `firstname` equals "Brian", while subsequent incremental reads will only return contacts whose `status` equals "active".
+
+### Filter values
+
+The `value` field accepts strings, booleans, and numbers:
+
+```json
+{ "fieldName": "name", "operator": "eq", "value": "Acme" }
+{ "fieldName": "isActive", "operator": "eq", "value": true }
+{ "fieldName": "employeeCount", "operator": "eq", "value": 50 }
+```
+
+### Supported providers
+
+Filters are currently supported for **HubSpot** and **Salesforce** read actions.
+
 ## Trigger a read
 
 You can call the [trigger read API](/reference/read/trigger-a-read) when you want Ampersand to read data for a particular customer. The data will be sent asynchronously to your destination. You can either use this API alongside a scheduled read (defined by the `schedule` field in the `amp.yaml`), or you can exclusively use the trigger read API without defining a schedule.

--- a/src/read-actions.mdx
+++ b/src/read-actions.mdx
@@ -4,7 +4,7 @@ title: "Read actions"
 
 A read action reads data from your customer's SaaS and send them to Destinations that you define.
 
-## Defining reads
+## Define reads
 
 To read an object, you need to specify:
 
@@ -139,13 +139,17 @@ The API returns:
 - **createTime** — When the backfill started
 - **updateTime** — When progress was last updated
 
-## Filtering records
+## Filter by field values
 
-You can filter which records are returned by a read action by setting `fieldFilters` in the [installation config](/reference/installation/create-a-new-installation). Filters are applied server-side by the SaaS provider, so only matching records are read and delivered to your destination.
+You can filter which records are returned by a read action by setting `fieldFilters` in the [installation config](/reference/installation/create-a-new-installation). Then only matching records are read and delivered to your destination.
 
 Each filter specifies a field name, an operator, and a value. Currently, only the `eq` (equals) operator is supported. Multiple filters are joined with AND logic, and each field can only have one condition.
 
-### Filter all reads
+<Note>
+  Filtered reads are currently only supported for **Salesforce** (CRM Module) and **HubSpot**.
+</Note>
+
+### Filter all records
 
 To filter both incremental reads and backfill, set `fieldFilters` on the object in the installation config:
 
@@ -170,9 +174,9 @@ To filter both incremental reads and backfill, set `fieldFilters` on the object 
 
 In this example, only contacts whose `firstname` equals "Brian" will be returned during both scheduled reads and backfill.
 
-### Filter backfill only
+### Backfill-specific filters
 
-If you want different filter behavior for backfill vs. incremental reads, you can set `fieldFilters` inside the `backfill` object. When set, this overrides the object-level `fieldFilters` during backfill.
+If you want different filter behavior for backfill vs. incremental reads, you can set `fieldFilters` inside the `backfill` object. When set, this overrides the object-level `fieldFilters` during backfill. Please note that [triggered reads](#trigger-a-read) will still use the object-level `fieldFilters`, if it is defined.
 
 ```json
 {
@@ -198,19 +202,15 @@ If you want different filter behavior for backfill vs. incremental reads, you ca
 
 In this example, the backfill will only return contacts whose `firstname` equals "Brian", while subsequent incremental reads will only return contacts whose `status` equals "active".
 
-### Filter values
+### Valid filter values
 
-The `value` field accepts strings, booleans, and numbers:
+The `value` field of the filter accepts strings, booleans, and numbers:
 
 ```json
 { "fieldName": "name", "operator": "eq", "value": "Acme" }
 { "fieldName": "isActive", "operator": "eq", "value": true }
 { "fieldName": "employeeCount", "operator": "eq", "value": 50 }
 ```
-
-### Supported providers
-
-Filters are currently supported for **HubSpot** and **Salesforce** read actions.
 
 ## Trigger a read
 

--- a/src/read-actions.mdx
+++ b/src/read-actions.mdx
@@ -141,7 +141,7 @@ The API returns:
 
 ## Filter by field values
 
-You can filter which records are returned by a read action by setting `fieldFilters` in the [installation config](/reference/installation/create-a-new-installation). Then only matching records are read and delivered to your destination.
+You can filter which records are returned by a read action by setting `fieldFilters` in the installation config when you are creating the installation using the [REST API](/reference/installation/create-a-new-installation) or Headless UI's [createInstallation method](/headless#create-update-and-delete-installations). Then only matching records are read and delivered to your destination.
 
 Each filter specifies a field name, an operator, and a value. Currently, only the `eq` (equals) operator is supported. Multiple filters are joined with AND logic, and each field can only have one condition.
 
@@ -151,7 +151,7 @@ Each filter specifies a field name, an operator, and a value. Currently, only th
 
 ### Filter all records
 
-To filter both incremental reads and backfill, set `fieldFilters` on the object in the installation config:
+To filter both incremental reads and backfill, set `fieldFilters` on the object in the installation config when you are creating the installation using the [REST API](/reference/installation/create-a-new-installation) or Headless UI's [createInstallation method](/headless#create-update-and-delete-installations):
 
 ```json
 {


### PR DESCRIPTION
## Description

Document the new `fieldFilters` feature for read actions (ENG-3705). Adds a "Filtering records" section covering:

- Object-level `fieldFilters` (applies to both incremental reads and backfill)
- Backfill-only `fieldFilters` (overrides object-level filter during backfill)
- Supported value types (string, boolean, number)
- Supported providers (HubSpot and Salesforce)

## Screenshot

<img width="1163" height="803" alt="Screenshot 2026-04-08 at 3 10 25 PM" src="https://github.com/user-attachments/assets/3ab0289c-ffdc-44c2-9abf-732583051139" />

<img width="1163" height="768" alt="Screenshot 2026-04-08 at 3 10 44 PM" src="https://github.com/user-attachments/assets/5658b1f4-b5a7-4b98-a34b-990f2702ca79" />

<img width="1164" height="366" alt="Screenshot 2026-04-08 at 3 11 04 PM" src="https://github.com/user-attachments/assets/f736aef0-ea64-4b10-ad55-91a0a716dcc8" />
