### PR TITLE
feat: update pipedrive connector documentation

### DIFF
--- a/src/provider-guides/pipedrive.mdx
+++ b/src/provider-guides/pipedrive.mdx
@@ -17,9 +17,17 @@ This connector supports:
 - [Write Actions](/write-actions)
 - [Proxy Actions](/proxy-actions), using the base URL `https://api.pipedrive.com`.
 
-### Supported Objects
+Pipedrive has a v1 and v2 API, if you would like to opt into the v2 API, then add `module: crm` to your amp.yaml file. Otherwise, v1 API is used. You can learn more about the difference between v1 and v2 API in [Pipedrive documentation](https://pipedrive.readme.io/docs/pipedrive-api-v2-migration-guide).
 
-#### v2 API Objects
+```yaml
+specVersion: 1.0.0
+integrations:
+  - name: read-write-pipedrive
+    provider: pipedrive
+    module: "crm" # The CRM module uses v2 APIs
+```
+
+### Supported Objects for V2 API
 
 The Pipedrive connector supports reading and writing to the following objects.
 
@@ -33,12 +41,32 @@ The Pipedrive connector supports reading and writing to the following objects.
 | [Products](https://developers.pipedrive.com/docs/api/v1/Products) | No |
 | [Stages](https://developers.pipedrive.com/docs/api/v1/Stages) | No |
 
+#### Reading Deal Products
 
-### Example Integration
+If you would like to read Products associated with Deals, add `products` as a field in `deals`.
+
+```yaml
+specVersion: 1.0.0
+integrations:
+  - name: read-write-pipedrive
+    provider: pipedrive
+    # The CRM module uses v2 APIs, which is required for to read deal products
+    module: "crm"
+    read:
+      objects:
+        - objectName: deals
+          destination: pipedrive-webhook
+          schedule: "*/10 * * * *" # Every 10 minutes
+          requiredFields:
+            - fieldName: id
+            - fieldName: products # Add products as a field
+```
+
+#### Example Integration
 
 For an example manifest file of a Pipedrive v2 integration, visit our [samples repo on Github](https://github.com/amp-labs/samples/blob/main/pipedrive/v2/amp.yaml).
 
-#### v1 API Objects
+### Supported Objects for V1 API
 
 The Pipedrive connector supports reading from the following objects using the v1 API:
 
@@ -107,7 +135,7 @@ The Pipedrive connector supports writing to the following objects:
 - [Users](https://developers.pipedrive.com/docs/api/v1/Users#addUser)
 - [Webhooks](https://developers.pipedrive.com/docs/api/v1/Webhooks#addWebhook)
 
-### Example Integration
+#### Example Integration
 
 For an example manifest file of a Pipedrive v1 integration, visit our [samples repo on Github](https://github.com/amp-labs/samples/blob/main/pipedrive/v1/amp.yaml).
 

--- a/src/provider-guides/pipedrive.mdx
+++ b/src/provider-guides/pipedrive.mdx
@@ -13,13 +13,34 @@ updatedAt: "Mon Jul 15 2024 15:56:36 GMT+0000 (Coordinated Universal Time)"
 
 This connector supports:
 
-- [Read Actions](/read-actions) including full historic backfill. Please note that incremental read is not supported, a full read of the Pipedrive instance will be done for each scheduled read.
+- [Read Actions](/read-actions) including full historic backfill. Incremental read is supported for select objects using the v2 API (see [v2 API Objects](#v2-api-objects) below). For all other objects, a full read of the Pipedrive instance will be done for each scheduled read.
 - [Write Actions](/write-actions)
 - [Proxy Actions](/proxy-actions), using the base URL `https://api.pipedrive.com`.
 
 ### Supported Objects
 
-The Pipedrive connector support reading from the following objects:
+#### v2 API Objects
+
+The Pipedrive connector supports reading and writing to the following objects.
+
+| Object | Incremental Read |
+|--------|:----------------:|
+| [Activities](https://developers.pipedrive.com/docs/api/v1/Activities) | Yes |
+| [Deals](https://developers.pipedrive.com/docs/api/v1/Deals) | Yes |
+| [Organizations](https://developers.pipedrive.com/docs/api/v1/Organizations) | Yes |
+| [Persons](https://developers.pipedrive.com/docs/api/v1/Persons) | Yes |
+| [Pipelines](https://developers.pipedrive.com/docs/api/v1/Pipelines) | No |
+| [Products](https://developers.pipedrive.com/docs/api/v1/Products) | No |
+| [Stages](https://developers.pipedrive.com/docs/api/v1/Stages) | No |
+
+
+### Example Integration
+
+For an example manifest file of a Pipedrive v2 integration, visit our [samples repo on Github](https://github.com/amp-labs/samples/blob/main/pipedrive/v2/amp.yaml).
+
+#### v1 API Objects
+
+The Pipedrive connector supports reading from the following objects using the v1 API:
 
 - [Activities](https://developers.pipedrive.com/docs/api/v1/Activities#getActivities)
 - [Activity Fields](https://developers.pipedrive.com/docs/api/v1/ActivityFields#getActivityFields)
@@ -56,7 +77,7 @@ The Pipedrive connector support reading from the following objects:
 - [User Settings](https://developers.pipedrive.com/docs/api/v1/UserSettings#getUserSettings)
 - [Webhooks](https://developers.pipedrive.com/docs/api/v1/Webhooks#getWebhooks)
 
-The Pipedrive connector support writing to the following objects:
+The Pipedrive connector supports writing to the following objects:
 
 - [Activities](https://developers.pipedrive.com/docs/api/v1/Activities#addActivity)
 - [Activity Types](https://developers.pipedrive.com/docs/api/v1/ActivityTypes#addActivityType)
@@ -88,7 +109,7 @@ The Pipedrive connector support writing to the following objects:
 
 ### Example Integration
 
-For an example manifest file of a Pipedrive integration, visit our [samples repo on Github](https://github.com/amp-labs/samples/blob/main/pipedrive/amp.yaml).
+For an example manifest file of a Pipedrive v1 integration, visit our [samples repo on Github](https://github.com/amp-labs/samples/blob/main/pipedrive/v1/amp.yaml).
 
 ## Before You Get Started
 


### PR DESCRIPTION
## Description
Pipedrives supports both v1 and v2 APIs. They are migrating to v2(slowly). Currently v2 supports 7 objects. This adds all v1 and v2 supported objects. 

## Screenshot
<img width="1470" height="887" alt="Screenshot 2026-04-15 at 12 16 51" src="https://github.com/user-attachments/assets/dcd225c2-6dbf-400c-95f2-4eb6653071c3" />
<img width="1466" height="884" alt="Screenshot 2026-04-15 at 12 17 04" src="https://github.com/user-attachments/assets/ad3e48bd-b1b6-4bad-a0e5-ca62bfb152e8" />
<img width="1470" height="890" alt="Screenshot 2026-04-15 at 12 17 14" src="https://github.com/user-attachments/assets/1ab5c132-3672-474e-8899-3bc2cd3fd733" />
<img width="1469" height="883" alt="Screenshot 2026-04-15 at 12 17 22" src="https://github.com/user-attachments/assets/4fbd91d4-b00a-45fa-9975-1c85ca8d91c9" />
<img width="1470" height="885" alt="Screenshot 2026-04-15 at 12 17 34" src="https://github.com/user-attachments/assets/0d647bf8-0908-4ea1-aedf-473ca5521bca" />


This depends on: https://github.com/amp-labs/samples/pull/120
