### PR TITLE
chore: move chat mode file to agents directory

### DIFF
--- a/.github/agents/ampersand-docs.agent.md
+++ b/.github/agents/ampersand-docs.agent.md
@@ -1,7 +1,7 @@
 ---
 description: 'Generate or update an Ampersand provider (connector) guide given provider metadata'
-tools: ['codebase', 'problems', 'fetch', 'searchResults', 'githubRepo', 'editFiles', 'search']
-model: Claude Sonnet 4
+tools: ['search/codebase', 'read/problems', 'web/fetch', 'search/searchResults', 'web/githubRepo', 'edit/editFiles', 'search']
+model: Auto (copilot)
 ---
 
 # Role & Mission


### PR DESCRIPTION
Chat modes is deprecated have been renamed to agents. so moved the md file to agents folder