### PR TITLE
[ENG-3748]feat: adding callout for hubspot associations

### DIFF
--- a/src/provider-guides/hubspot.mdx
+++ b/src/provider-guides/hubspot.mdx
@@ -54,7 +54,7 @@ To read users from your customer's HubSpot workspace, enable the `crm.objects.us
 ### Associations
 
 <Note>
-  HubSpot associations is a private preview feature. Please contact support@withampersand.com to get it set up for you.
+  HubSpot associations is a private preview feature where you can retrieve associated records when using Read Actions or Subscribe Actions. Please contact support@withampersand.com if you wish to use it.
 </Note>
 
 ### Example Integration

--- a/src/provider-guides/hubspot.mdx
+++ b/src/provider-guides/hubspot.mdx
@@ -51,6 +51,12 @@ To read users from your customer's HubSpot workspace, enable the `crm.objects.us
       mapToName: emailAddress
 ```
 
+### Associations
+
+<Note>
+  HubSpot associations is a private preview feature. Please contact support@withampersand.com to get it set up for you.
+</Note>
+
 ### Example Integration
 
 For an example manifest file, visit our [samples repo on Github](https://github.com/amp-labs/samples/blob/main/hubspot/amp.yaml).


### PR DESCRIPTION
## Description
* Adds an Associations subsection to the HubSpot provider guide with a <Note> callout flagging it as a private preview feature and pointing users to support@withampersand.com to get set up.
## Screenshot

Please include a screenshot of the documentation running locally with `cd src && mint dev`. 
<img width="1184" height="1088" alt="Screenshot 2026-04-20 at 16 35 09" src="https://github.com/user-attachments/assets/494e9d0e-f64c-4f8e-8a19-105d9eed01bb" />
