### PR TITLE
[ENG-3770] docs: add `connection.refreshed` and `connection.deleted` notifications

### DIFF
--- a/src/notifications/notification-payloads.mdx
+++ b/src/notifications/notification-payloads.mdx
@@ -373,7 +373,9 @@ Note: `error` describes what went wrong during the triggered read.
 Note: For partial failures, `success` is `false` with both `successfulRecordIds` and `errors` populated.
 </Accordion>
 
-<Accordion title="connection.created">
+<Accordion title="Connection events (created, refreshed, deleted)">
+`connection.created`, `connection.refreshed`, and `connection.deleted` share the same payload shape. `notificationType` reflects the specific event.
+
 **Webhook destination payload:**
 ```json
 {

--- a/src/notifications/overview.mdx
+++ b/src/notifications/overview.mdx
@@ -32,6 +32,8 @@ Ampersand supports the following notification event types:
 
 **Connection**
 - **`connection.created`**: Fires when a new OAuth connection is established with a SaaS provider
+- **`connection.refreshed`**: Fires when a connection's OAuth access token is refreshed
+- **`connection.deleted`**: Fires when a connection is deleted
 - **`connection.error`**: Fires when there's an error with an OAuth connection, such as authentication failures or token refresh issues
 
 **Destination**


### PR DESCRIPTION
## Description

Add docs for new notification types. 

## Screenshot

Please include a screenshot of the documentation running locally with `cd src && mint dev`. 
<img width="1461" height="1107" alt="Screenshot 2026-04-21 at 2 22 12 PM" src="https://github.com/user-attachments/assets/57af5b96-b4e5-479b-beb8-46ef6cf37c9e" />
<img width="1294" height="1164" alt="Screenshot 2026-04-21 at 2 22 38 PM" src="https://github.com/user-attachments/assets/39fcab9c-23a5-4368-be97-cd514325e2a4" />


