### PR TITLE
[ENG-3862] docs: pardot unreadable custom fields

### DIFF
--- a/src/provider-guides/salesforce.mdx
+++ b/src/provider-guides/salesforce.mdx
@@ -119,7 +119,7 @@ The Salesforce connector supports the following **Account Engagement** module ob
   </table>
 </div>
 
-_* Because Salesforce's [bulk Prospect Query endpoint](https://developer.salesforce.com/docs/marketing/pardot/guide/prospect-v5.html#requesting-custom-fields) does not support `Multi-Select` or `Checkbox` custom fields on `prospects`., these field types will not appear in the Ampersand field mapping UI and cannot be read or written through standard Read or Write Actions._
+_* Because Salesforce's [bulk Prospect Query endpoint](https://developer.salesforce.com/docs/marketing/pardot/guide/prospect-v5.html#requesting-custom-fields) does not support `Multi-Select` or `Checkbox` custom fields on `prospects`, these field types will not appear in the Ampersand field mapping UI and cannot be read or written through standard Read or Write Actions._
 
 ### Example integration
 

--- a/src/provider-guides/salesforce.mdx
+++ b/src/provider-guides/salesforce.mdx
@@ -106,7 +106,7 @@ The Salesforce connector supports the following **Account Engagement** module ob
       <tr style={{ display: 'table-row' }}><td style={{textAlign: 'left'}}><a href="https://developer.salesforce.com/docs/marketing/pardot/guide/list-v5.html">lists</a></td><td><Check/></td><td><Check/></td></tr>
       <tr style={{ display: 'table-row' }}><td style={{textAlign: 'left'}}><a href="https://developer.salesforce.com/docs/marketing/pardot/guide/opportunity-v5.html">opportunities</a></td><td><Check/></td><td><Cross/></td></tr>
       <tr style={{ display: 'table-row' }}><td style={{textAlign: 'left'}}><a href="https://developer.salesforce.com/docs/marketing/pardot/guide/prospect-account-v5.html">prospect-accounts</a></td><td><Check/></td><td><Cross/></td></tr>
-      <tr style={{ display: 'table-row' }}><td style={{textAlign: 'left'}}><a href="https://developer.salesforce.com/docs/marketing/pardot/guide/prospect-v5.html">prospects</a></td><td><Check/></td><td><Check/></td></tr>
+      <tr style={{ display: 'table-row' }}><td style={{textAlign: 'left'}}><a href="https://developer.salesforce.com/docs/marketing/pardot/guide/prospect-v5.html">prospects</a><sup>{"*"}</sup></td><td><Check/></td><td><Check/></td></tr>
       <tr style={{ display: 'table-row' }}><td style={{textAlign: 'left'}}><a href="https://developer.salesforce.com/docs/marketing/pardot/guide/tag-v5.html">tags</a></td><td><Check/></td><td><Check/></td></tr>
       <tr style={{ display: 'table-row' }}><td style={{textAlign: 'left'}}><a href="https://developer.salesforce.com/docs/marketing/pardot/guide/tagged-object-v5.html">tagged-objects</a></td><td><Check/></td><td><Cross/></td></tr>
       <tr style={{ display: 'table-row' }}><td style={{textAlign: 'left'}}><a href="https://developer.salesforce.com/docs/marketing/pardot/guide/tracker-domain-v5.html">tracker-domains</a></td><td><Check/></td><td><Cross/></td></tr>
@@ -118,6 +118,8 @@ The Salesforce connector supports the following **Account Engagement** module ob
     </tbody>
   </table>
 </div>
+
+_* Salesforce's [bulk Prospect Query endpoint](https://developer.salesforce.com/docs/marketing/pardot/guide/prospect-v5.html#requesting-custom-fields) does not support `Multi-Select` or `Checkbox` custom fields on `prospects`. These field types will not appear in the Ampersand field mapping UI and cannot be read or written through standard Read or Write Actions._
 
 ### Example integration
 

--- a/src/provider-guides/salesforce.mdx
+++ b/src/provider-guides/salesforce.mdx
@@ -119,7 +119,7 @@ The Salesforce connector supports the following **Account Engagement** module ob
   </table>
 </div>
 
-_* Salesforce's [bulk Prospect Query endpoint](https://developer.salesforce.com/docs/marketing/pardot/guide/prospect-v5.html#requesting-custom-fields) does not support `Multi-Select` or `Checkbox` custom fields on `prospects`. These field types will not appear in the Ampersand field mapping UI and cannot be read or written through standard Read or Write Actions._
+_* Because Salesforce's [bulk Prospect Query endpoint](https://developer.salesforce.com/docs/marketing/pardot/guide/prospect-v5.html#requesting-custom-fields) does not support `Multi-Select` or `Checkbox` custom fields on `prospects`., these field types will not appear in the Ampersand field mapping UI and cannot be read or written through standard Read or Write Actions._
 
 ### Example integration
 


### PR DESCRIPTION
## Description

Document limitation that we don't enable selecting MultiSelect/Checkbox Custom Fields for Pardot, due to provider limitations.

## Screenshot

Please include a screenshot of the documentation running locally with `cd src && mint dev`. 

<img width="1153" height="600" alt="Screenshot 2026-04-21 at 3 10 14 PM" src="https://github.com/user-attachments/assets/8aa5d8e0-6a1f-410e-a8dc-546c89165b02" />
