### PR TITLE
HousecallPro: document employee subscribe limitation

### DIFF
--- a/src/provider-guides/housecallPro.mdx
+++ b/src/provider-guides/housecallPro.mdx
@@ -21,10 +21,24 @@ The Housecall Pro connector supports the following objects.
 
 - [customers](https://docs.housecallpro.com/docs/housecall-public-api/042bd3bf861ae-get-customers) (read, subscribe, write; incremental read supported)
 - [employees](https://docs.housecallpro.com/docs/housecall-public-api/303ee235f23fa-get-employees) (read, subscribe)
-  <Note>
-    In Housecall Pro’s webhook UI, this event appears as pro.created, but the
-    actual payload uses employee.created.
-  </Note>
+
+      <Note>
+
+  In Housecall Pro’s webhook UI, this event appears as pro.created, but the
+  actual payload uses employee.created.
+
+  Use [`otherEvents`](/subscribe-actions#other-events) for **`employee.created`**, not `createEvent` (Housecall Pro API limitation).
+
+  ```yaml
+  - objectName: employees
+    destination: housecallProWebhook
+    inheritFieldsAndMapping: true
+    otherEvents:
+      - employee.created
+  ```
+
+      </Note>
+
 - [estimates](https://docs.housecallpro.com/docs/housecall-public-api/e430ba3d520a0-get-estimates) (read, subscribe, write; incremental read supported)
 - [events](https://docs.housecallpro.com/docs/housecall-public-api/5f8b2b787f4ba-get-events) (read; incremental read supported)
 - [jobs](https://docs.housecallpro.com/docs/housecall-public-api/6c97704da8bf3-get-jobs) (read, subscribe, write; incremental read supported)


### PR DESCRIPTION
## Description
Documents that employee.created should be wired with otherEvents, not createEvent.
Includes a small amp.yaml fragment showing the otherEvents configuration.
## Screenshot
<img width="1778" height="1099" alt="image" src="https://github.com/user-attachments/assets/c9a32540-8e07-426a-bb87-52abcbc9ad8f" />
