### PR TITLE
[ENG-3906] feat(hubspot): Marketing campaigns, emails

### DIFF
--- a/src/provider-guides/hubspot.mdx
+++ b/src/provider-guides/hubspot.mdx
@@ -15,24 +15,29 @@ The Hubspot connector supports:
 
 ### Supported Objects
 
-The Hubspot connector supports writing to and reading from the following objects:
+#### Reading, writing CRM Objects
+The connector supports reading from and writing to the following *CRM objects*,
+including [standard fields](https://docs.google.com/spreadsheets/d/1FGc9zT_J9dyGghDxvqeioAva-5Gj7-2DQzKNMrbrPvw/view?usp=sharing) and custom fields:
 
-- [companies](https://developers.hubspot.com/docs/api/crm/companies)
-- [contacts](https://developers.hubspot.com/docs/api/crm/contacts)
-- [deals](https://developers.hubspot.com/docs/api/crm/deals)
-- [emails](https://developers.hubspot.com/docs/guides/api/crm/engagements/email)
-- [calls](https://developers.hubspot.com/docs/guides/api/crm/engagements/calls)
-- [meetings](https://developers.hubspot.com/docs/guides/api/crm/engagements/meetings)
-- [notes](https://developers.hubspot.com/docs/guides/api/crm/engagements/notes)
-- All other [standard CRM objects](https://developers.hubspot.com/docs/guides/api/crm/understanding-the-crm#object-type-ids)
+- [calls](https://developers.hubspot.com/docs/api-reference/legacy/crm/activities/calls/guide)
+- [companies](https://developers.hubspot.com/docs/api-reference/legacy/crm/objects/companies/guide)
+- [contacts](https://developers.hubspot.com/docs/api-reference/legacy/crm/objects/contacts/guide)
+- [deals](https://developers.hubspot.com/docs/api-reference/legacy/crm/objects/deals/guide)
+- [emails](https://developers.hubspot.com/docs/api-reference/legacy/crm/activities/emails/guide)
+- [meetings](https://developers.hubspot.com/docs/api-reference/legacy/crm/activities/meetings/guide)
+- [notes](https://developers.hubspot.com/docs/api-reference/legacy/crm/activities/notes/guide)
+- All other [standard CRM objects](https://developers.hubspot.com/docs/guides/crm/understanding-the-crm#object-type-ids)
 - Custom CRM objects
 
-For each of these objects, the connector supports standard fields ([list of standard fields](https://docs.google.com/spreadsheets/d/1FGc9zT_J9dyGghDxvqeioAva-5Gj7-2DQzKNMrbrPvw/view?usp=sharing)) and custom fields.
+#### Read-Only CRM Objects
+The connector supports reading from:
+- [lists](https://developers.hubspot.com/docs/api-reference/latest/crm/lists/guide) (note: incremental reads not supported for Lists)
+- Users and owners ([see below](#reading-users-and-owners))
 
-The Hubspot connector only supports reading from:
-
-- [lists](https://developers.hubspot.com/docs/guides/api/crm/lists/overview) (note: incremental reads not supported for Lists)
-- Users and owners (see below)
+#### Read-Only Marketing Objects
+The connector supports reading from:
+- [campaigns](https://developers.hubspot.com/docs/api-reference/latest/marketing/campaigns/guide)
+- [marketing/emails](https://developers.hubspot.com/docs/api-reference/latest/marketing/marketing-emails/guide)
 
 #### Reading users and owners
 


### PR DESCRIPTION
## Description

* Updated old URLs. They were valid, but Hubspot would redirect to newer web pages.
* Added marketing objects as dedicated section to avoid mixing with CRM and CRM emails.
* See blow -- is now a relative link to the header.

## Screenshot
 
<img width="767" height="881" alt="image" src="https://github.com/user-attachments/assets/ec4f3cf8-8c5b-4eb6-93c2-10e4c9fa8ef5" />
