### PR TITLE
[Docs] Subscribe permission `Modify Metadata Through Metadata API Functions`

### DIFF
--- a/src/customer-guides/salesforce.mdx
+++ b/src/customer-guides/salesforce.mdx
@@ -317,7 +317,7 @@ If the integration contains Subscribe Actions, a number of special permissions a
 - `View Roles and Role Hierarchy`: Ensures the integration has the correct visibility context so Salesforce can successfully send events; without this, events may be generated but not delivered.
 - `Manage Custom Permissions`: Allows the integration to create and manage dedicated event channels and channel memberships used specifically for the installation's subscription events.
 - `Customize Application`: Required to configure artifacts like Named Credentials, which allows subscription to happen in a secure way.
-- `Modify Metadata Through Metadata API Functions`: Required to configure change data capture setting like event channels and event channel members. 
+- `Modify Metadata Through Metadata API Functions`: Required to configure change data capture settings like event channels and event channel memberships through Metadata API. 
 
 To ensure that you have the necessary permission to use Subscribe Actions, please follow these instructions:
 - [For a Profile](#1-configure-system-permissions)

--- a/src/customer-guides/salesforce.mdx
+++ b/src/customer-guides/salesforce.mdx
@@ -313,11 +313,15 @@ To ensure that you have the necessary system permission, please follow these ins
 
 If the integration contains Subscribe Actions, a number of special permissions are required. Here's an explanation of why each permission is necessary:
 
+These permissions need to be explicitly enabled:
+
+- `Modify Metadata Through Metadata API Functions`: Required to configure event channels and event channel memberships through Metadata API.
+- `Customize Application`: Required to configure artifacts like Named Credentials, which allows Ampersand to securely connect to the event channels.
+
+Salesforce auto-enables these when you enable the above permissions, because they dependent permissions:
 - `View Setup and Configuration`: Enables the integration to access Salesforce setup configuration in order to create webhook subscription settings.
 - `View Roles and Role Hierarchy`: Ensures the integration has the correct visibility context so Salesforce can successfully send events; without this, events may be generated but not delivered.
 - `Manage Custom Permissions`: Allows the integration to create and manage dedicated event channels and channel memberships used specifically for the installation's subscription events.
-- `Customize Application`: Required to configure artifacts like Named Credentials, which allows subscription to happen in a secure way.
-- `Modify Metadata Through Metadata API Functions`: Required to configure change data capture settings like event channels and event channel memberships through Metadata API. 
 
 To ensure that you have the necessary permission to use Subscribe Actions, please follow these instructions:
 - [For a Profile](#1-configure-system-permissions)

--- a/src/customer-guides/salesforce.mdx
+++ b/src/customer-guides/salesforce.mdx
@@ -317,7 +317,7 @@ If the integration contains Subscribe Actions, a number of special permissions a
 - `View Roles and Role Hierarchy`: Ensures the integration has the correct visibility context so Salesforce can successfully send events; without this, events may be generated but not delivered.
 - `Manage Custom Permissions`: Allows the integration to create and manage dedicated event channels and channel memberships used specifically for the installation's subscription events.
 - `Customize Application`: Required to configure artifacts like Named Credentials, which allows subscription to happen in a secure way.
-- `Modify Metadata Through Metadata API Functions`: Required to configure change data capture setting like even channels and channel members. 
+- `Modify Metadata Through Metadata API Functions`: Required to configure change data capture setting like event channels and event channel members. 
 
 To ensure that you have the necessary permission to use Subscribe Actions, please follow these instructions:
 - [For a Profile](#1-configure-system-permissions)

--- a/src/customer-guides/salesforce.mdx
+++ b/src/customer-guides/salesforce.mdx
@@ -317,6 +317,7 @@ If the integration contains Subscribe Actions, a number of special permissions a
 - `View Roles and Role Hierarchy`: Ensures the integration has the correct visibility context so Salesforce can successfully send events; without this, events may be generated but not delivered.
 - `Manage Custom Permissions`: Allows the integration to create and manage dedicated event channels and channel memberships used specifically for the installation's subscription events.
 - `Customize Application`: Required to configure artifacts like Named Credentials, which allows subscription to happen in a secure way.
+- `Modify Metadata Through Metadata API Functions`: Required to configure change data capture setting like even channels and channel members. 
 
 To ensure that you have the necessary permission to use Subscribe Actions, please follow these instructions:
 - [For a Profile](#1-configure-system-permissions)


### PR DESCRIPTION
## Description
- `Modify Metadata Through Metadata API Functions` into Salesforce Subscribe Action Permission List

## Issue Before
```
2026-05-10 21:54:25 time=2026-05-11T04:54:25.019Z level=ERROR msg="HTTP request failed" method=POST url=https://withampersand.my.salesforce.com/services/data/v60.0/tooling/sobjects/PlatformEventChannel correlationId=ad8cc914-2f67-473e-b0c1-008b708e884d error="HTTP status 400: caller error: [{\"message\":\"use of the Metadata API requires a user with the ModifyAllData or ModifyMetadata permissions\",\"errorCode\":\"INSUFFICIENT_ACCESS\"}]"
```

## Screenshot
<img width="781" height="564" alt="Screenshot 2026-05-10 at 10 56 13 PM" src="https://github.com/user-attachments/assets/937a3433-2c7b-41af-86d2-b46898260399" />


Please include a screenshot of the documentation running locally with `cd src && mint dev`. 
