### PR TITLE
scripts(drift-check): add v1 static detector for provider guides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 
 node_modules
 .env
-drift-report/
+/drift-report/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 
 node_modules
 .env
+drift-report/

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
         "gen-api-pages:read": "cd src && mintlify-scrape openapi-file -o reference read.json | tail -n +2 > reference/read.json",
         "gen-api-pages:write": "cd src && mintlify-scrape openapi-file -o reference write.json | tail -n +2 > reference/write.json",
         "gen-api-pages:search": "cd src && mintlify-scrape openapi-file -o reference search.json | tail -n +2 > reference/search.json",
-        "gen-docs": "cd src && tsx generate-docs.ts docs.json"
+        "gen-docs": "cd src && tsx generate-docs.ts docs.json",
+        "drift-check": "tsx scripts/drift-check/index.ts"
     },
     "devDependencies": {
         "@mintlify/scraping": "3.0.137",

--- a/scripts/drift-check/README.md
+++ b/scripts/drift-check/README.md
@@ -1,0 +1,110 @@
+# Drift check
+
+Static comparison of provider guides against the connectors catalog. Detects three classes of drift between the docs at `src/provider-guides/` and the catalog at [`amp-labs/connectors/internal/generated/catalog.json`](https://github.com/amp-labs/connectors/blob/main/internal/generated/catalog.json).
+
+## Quick start
+
+```shell
+pnpm run drift-check                       # full sweep, default ./drift-report/
+pnpm run drift-check -- --out /tmp/out     # custom output directory
+pnpm run drift-check -- --mode provider --provider hubspot
+pnpm run drift-check -- --fail-on-error    # exit non-zero on any error finding
+```
+
+Both `pnpm run drift-check --out X` and `pnpm run drift-check -- --out X` work. The script writes two files to the output directory:
+
+- `drift-report.json`: canonical findings, one object per finding.
+- `drift-report.md`: human-readable rollup grouped by severity.
+
+## What it checks
+
+| Kind | Severity | What triggers it |
+|---|---|---|
+| `undocumented-provider` | error | Catalog has a provider; no guide exists; no allowance in `recipes.ts` |
+| `undocumented-provider-allowance-expired` | warning | An entry in `undocumentedAllowed` has passed its `until` date |
+| `guide-without-catalog-entry` | error | A guide resolves to a catalog key that does not exist |
+| `doc-overclaims-{read,write,subscribe,proxy,search}` | error | Guide claims an action; neither provider-level nor any module-level support flag is true |
+| `broken-sample-link` | error | Guide links to a `samples` manifest that 404s |
+
+The check is **module-aware**: a guide claim is considered valid if either the provider-level flag is true *or* any module-level flag is true. So Google's `subscribe` claim is valid because `modules.gmail.support.subscribe == true`, even though `support.subscribe == false` at the provider level.
+
+For multi-module providers, findings include `"module": "all"` since the v1 detector does not attempt to attribute the claim to a specific module.
+
+## Modes
+
+- **`--mode full`** (default): scan every guide and check every catalog provider for missing docs.
+- **`--mode per-pr --changed <path>...`**: scan only the listed `.mdx` files. Skips the undocumented-provider check (it requires a global view). Suitable for per-PR CI where you only want to validate touched files.
+- **`--mode provider --provider <catalogKey>`**: scan only the guide that resolves to the given catalog key. Useful for guide authors iterating locally.
+
+## Resolving guide slug to catalog key
+
+Guides resolve to a catalog key in this order:
+
+1. Frontmatter `provider` field, case preserved.
+2. `slugOverrides` in `recipes.ts` (for genuine name differences, not case).
+3. Case-insensitive match against catalog keys (handles `aweber.mdx` → `aWeber`).
+4. Filename slug, verbatim (fails as `guide-without-catalog-entry` if no catalog entry).
+
+This means most case differences between filenames and catalog keys (73 of 227 catalog keys are mixed-case) need no recipe at all.
+
+## Adding a recipe
+
+Edit `recipes.ts`. Two surfaces:
+
+### `slugOverrides`
+
+Use only when the filename slug and the catalog key are genuinely different strings, not just case differences. Examples:
+
+```ts
+slugOverrides: {
+  instantly: 'instantlyAI',                    // file documents the V2 catalog entry
+  'google-workspace-delegation': 'googleWorkspaceDelegation',  // hyphen vs camelCase
+  jira: 'atlassian',                           // alias guide for a family
+}
+```
+
+### `undocumentedAllowed`
+
+Use when a catalog entry intentionally has no guide. Every allowance has a reason and an `until` date so it cannot persist forever.
+
+```ts
+undocumentedAllowed: [
+  {
+    provider: 'instantly',
+    reason: 'Legacy V1 connector; current public guide covers instantlyAI.',
+    until: '2026-09-01',
+  },
+]
+```
+
+When `until` passes, the entry becomes a warning (`undocumented-provider-allowance-expired`) until renewed or removed.
+
+## What v1 deliberately does not check
+
+These are out of scope for v1. PR 3 or later may add them.
+
+- **Object-name drift between guides and connector source.** The connector source under `providers/<slug>/` enumerates supported objects; v1 does not parse Go.
+- **Provider public-doc drift.** Comparing each guide's setup steps against the provider's own developer documentation requires per-provider HTML parsing.
+- **Provider product-UI drift.** Validating screenshots and GIFs against the actual provider dashboards requires real accounts, MFA, and is explicitly out of scope.
+- **Runtime smoke tests.** Actually exercising read/write/proxy against a live provider requires sandbox accounts and is a separate program.
+
+## Severity → CI behavior
+
+When wired into CI (PR 3), the intended mapping:
+
+- **error**: fails CI when the change is on a touched file (per-PR mode).
+- **warning**: reported, never fails CI.
+- **info**: reported, never fails CI.
+
+The script accepts `--fail-on-error` for the CI invocation.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `index.ts` | CLI entry; orchestrates the three checks |
+| `catalog.ts` | Fetch `catalog.json`; module-aware capability helpers |
+| `docs.ts` | Scan `.mdx` files; extract frontmatter and the five action-link patterns |
+| `samples.ts` | HEAD-check each sample manifest URL |
+| `recipes.ts` | `slugOverrides` and `undocumentedAllowed` |
+| `report.ts` | Finding type, JSON canonical output, Markdown rollup |

--- a/scripts/drift-check/README.md
+++ b/scripts/drift-check/README.md
@@ -1,118 +1,66 @@
 # Drift check
 
-Static comparison of provider guides against the connectors catalog. Detects three classes of drift between the docs at `src/provider-guides/` and the catalog at [`amp-labs/connectors/internal/generated/catalog.json`](https://github.com/amp-labs/connectors/blob/main/internal/generated/catalog.json).
+Compares provider-guide claims against the generated [`amp-labs/connectors`](https://github.com/amp-labs/connectors/blob/main/internal/generated/catalog.json) catalog. Static, no credentials, no runtime calls.
 
 ## Quick start
 
 ```shell
-pnpm run drift-check                       # full sweep, default ./drift-report/
-pnpm run drift-check -- --out /tmp/out     # custom output directory
+pnpm run drift-check                         # full sweep, default ./drift-report/
+pnpm run drift-check -- --out /tmp/out       # custom output directory
 pnpm run drift-check -- --mode provider --provider hubspot
-pnpm run drift-check -- --fail-on-error    # exit non-zero on any error finding
+pnpm run drift-check -- --fail-on-error      # exit non-zero on any error finding
 ```
 
-Both `pnpm run drift-check --out X` and `pnpm run drift-check -- --out X` work. The script writes two files to the output directory:
+Both `--out X` and `-- --out X` (the pnpm forwarding form) work. Output is written to `drift-report.json` (canonical) and `drift-report.md` (human-readable rollup).
 
-- `drift-report.json`: canonical findings, one object per finding.
-- `drift-report.md`: human-readable rollup grouped by severity.
+## Modes
 
-## What it checks
+- `full` (default): scan every guide; run the undocumented-provider check.
+- `per-pr --changed <path>...`: scan only the listed `.mdx` files. Skips the undocumented check (needs a global view).
+- `provider --provider <catalogKey>`: scan a single guide. Useful while iterating.
 
-| Kind | Severity | What triggers it |
+## Finding types
+
+| Kind | Severity | Triggers |
 |---|---|---|
-| `undocumented-provider` | error | Catalog has a provider; no guide exists; no allowance in `recipes.ts` |
+| `undocumented-provider` | error | Catalog has a provider; no guide; no allowance |
 | `undocumented-provider-allowance-expired` | warning | An entry in `undocumentedAllowed` has passed its `until` date |
 | `guide-without-catalog-entry` | error | A guide resolves to a catalog key that does not exist |
 | `doc-overclaims-{read,write,subscribe,proxy,search}` | error | Guide claims an action; neither provider-level nor any module-level support flag is true |
 | `broken-sample-link` | error | Guide links to a `samples` manifest that 404s |
 
-The check is **module-aware**: a guide claim is considered valid if either the provider-level flag is true *or* any module-level flag is true. So Google's `subscribe` claim is valid because `modules.gmail.support.subscribe == true`, even though `support.subscribe == false` at the provider level.
+Module-aware: a claim is valid if either the provider-level flag is true *or* any module-level flag is true. Multi-module provider findings carry `"module": "all"` since v1 does not attribute the claim to a specific module.
 
-For multi-module providers, findings include `"module": "all"` since the v1 detector does not attempt to attribute the claim to a specific module.
+## What this does not prove
 
-## Modes
+This check uses the generated connectors catalog from `main`. It does **not** validate the deployed `/v1/providers` API against its declared shape, and it does **not** prove that read/write/proxy/subscribe calls succeed at runtime. Several drift surfaces are deliberately out of scope:
 
-- **`--mode full`** (default): scan every guide and check every catalog provider for missing docs.
-- **`--mode per-pr --changed <path>...`**: scan only the listed `.mdx` files. Skips the undocumented-provider check (it requires a global view). Suitable for per-PR CI where you only want to validate touched files.
-- **`--mode provider --provider <catalogKey>`**: scan only the guide that resolves to the given catalog key. Useful for guide authors iterating locally.
-
-## Resolving guide slug to catalog key
-
-Guides resolve to a catalog key in this order:
-
-1. Frontmatter `provider` field, case preserved.
-2. `slugOverrides` in `recipes.ts` (for genuine name differences, not case).
-3. Case-insensitive match against catalog keys (handles `aweber.mdx` → `aWeber`).
-4. Filename slug, verbatim (fails as `guide-without-catalog-entry` if no catalog entry).
-
-This means most case differences between filenames and catalog keys (73 of 227 catalog keys are mixed-case) need no recipe at all.
+| Surface | Why out of scope |
+|---|---|
+| Connector Go source vs generated catalog | Regeneration lag; lives in the connectors repo |
+| Generated catalog vs live `/v1/providers` | Deployment lag; separate cheap check |
+| Live API declared shape vs runtime behavior | Requires sandbox accounts; separate program |
+| Guides vs connector source object names | Requires parsing Go; deferred to a follow-up PR |
+| Guides vs provider's own developer docs | Per-provider HTML parsing |
+| Guides vs provider product UIs (screenshots, GIFs) | Manual surface; account + MFA |
 
 ## Adding a recipe
 
-Edit `recipes.ts`. Two surfaces:
+Edit `recipes.ts`. Two surfaces, both intentionally sparse.
 
-### `slugOverrides`
-
-Use only when the filename slug and the catalog key are genuinely different strings, not just case differences. Examples:
+**`slugOverrides`** — when the filename slug and the catalog key are different *strings* (not just different cases — case differences are handled automatically):
 
 ```ts
 slugOverrides: {
-  instantly: 'instantlyAI',                    // file documents the V2 catalog entry
-  'google-workspace-delegation': 'googleWorkspaceDelegation',  // hyphen vs camelCase
-  jira: 'atlassian',                           // alias guide for a family
+  instantly: 'instantlyAI',
+  jira: 'atlassian',
 }
 ```
 
-### `undocumentedAllowed`
-
-Use when a catalog entry intentionally has no guide. Every allowance has a reason and an `until` date so it cannot persist forever.
+**`undocumentedAllowed`** — when a catalog entry intentionally has no guide. Every entry needs a reason and a time-bounded `until` so the allowance cannot persist forever:
 
 ```ts
-undocumentedAllowed: [
-  {
-    provider: 'instantly',
-    reason: 'Legacy V1 connector; current public guide covers instantlyAI.',
-    until: '2026-09-01',
-  },
-]
+{ provider: 'adyenTest', reason: 'Internal test variant.', until: '2027-01-01' }
 ```
 
-When `until` passes, the entry becomes a warning (`undocumented-provider-allowance-expired`) until renewed or removed.
-
-## What this check does not prove
-
-This check uses the generated connectors catalog from `main`; it does not compare against the deployed `/v1/providers` API or prove runtime API behavior.
-
-It does **not** prove that read/write/proxy/subscribe calls succeed at runtime, and it does not validate the deployed Ampersand API against its declared shape.
-
-Concretely, the drift surfaces this check ignores:
-
-| Surface | Out of scope because |
-|---|---|
-| **Connector Go source vs generated `catalog.json`** | The connectors repo generates the catalog from source. Regeneration lag is the connectors team's problem, not the docs' problem. |
-| **Generated `catalog.json` vs live `/v1/providers`** | Deployment lag. Catalog-vs-live is a separate cheap check (no credentials needed); track it under a follow-up PR. |
-| **Live API declared shape vs actual runtime behavior** | Whether `read` actually works requires sandbox accounts, installations, and real provider credentials. That is a separate program, not a docs-repo check. |
-| **Object-name drift between guides and connector source** | Requires parsing Go. Deferred to a later PR that adds `connectors.ts`. |
-| **Provider public-doc drift** | Comparing guide steps against the provider's own developer documentation requires per-provider HTML parsing. |
-| **Provider product-UI drift** | Validating screenshots and GIFs against live provider dashboards requires real accounts and MFA. Manual surface. |
-
-## Severity → CI behavior
-
-When wired into CI (PR 3), the intended mapping:
-
-- **error**: fails CI when the change is on a touched file (per-PR mode).
-- **warning**: reported, never fails CI.
-- **info**: reported, never fails CI.
-
-The script accepts `--fail-on-error` for the CI invocation.
-
-## Files
-
-| File | Purpose |
-|---|---|
-| `index.ts` | CLI entry; orchestrates the three checks |
-| `catalog.ts` | Fetch `catalog.json`; module-aware capability helpers |
-| `docs.ts` | Scan `.mdx` files; extract frontmatter and the five action-link patterns |
-| `samples.ts` | HEAD-check each sample manifest URL |
-| `recipes.ts` | `slugOverrides` and `undocumentedAllowed` |
-| `report.ts` | Finding type, JSON canonical output, Markdown rollup |
+When `until` passes, the entry becomes an `undocumented-provider-allowance-expired` warning until renewed or removed.

--- a/scripts/drift-check/README.md
+++ b/scripts/drift-check/README.md
@@ -81,7 +81,9 @@ When `until` passes, the entry becomes a warning (`undocumented-provider-allowan
 
 ## What this check does not prove
 
-This check validates docs against the connector catalog. It does **not** prove that read/write/proxy/subscribe calls succeed at runtime, and it does not validate the deployed Ampersand API against its declared shape.
+This check uses the generated connectors catalog from `main`; it does not compare against the deployed `/v1/providers` API or prove runtime API behavior.
+
+It does **not** prove that read/write/proxy/subscribe calls succeed at runtime, and it does not validate the deployed Ampersand API against its declared shape.
 
 Concretely, the drift surfaces this check ignores:
 

--- a/scripts/drift-check/README.md
+++ b/scripts/drift-check/README.md
@@ -79,14 +79,20 @@ undocumentedAllowed: [
 
 When `until` passes, the entry becomes a warning (`undocumented-provider-allowance-expired`) until renewed or removed.
 
-## What v1 deliberately does not check
+## What this check does not prove
 
-These are out of scope for v1. PR 3 or later may add them.
+This check validates docs against the connector catalog. It does **not** prove that read/write/proxy/subscribe calls succeed at runtime, and it does not validate the deployed Ampersand API against its declared shape.
 
-- **Object-name drift between guides and connector source.** The connector source under `providers/<slug>/` enumerates supported objects; v1 does not parse Go.
-- **Provider public-doc drift.** Comparing each guide's setup steps against the provider's own developer documentation requires per-provider HTML parsing.
-- **Provider product-UI drift.** Validating screenshots and GIFs against the actual provider dashboards requires real accounts, MFA, and is explicitly out of scope.
-- **Runtime smoke tests.** Actually exercising read/write/proxy against a live provider requires sandbox accounts and is a separate program.
+Concretely, the drift surfaces this check ignores:
+
+| Surface | Out of scope because |
+|---|---|
+| **Connector Go source vs generated `catalog.json`** | The connectors repo generates the catalog from source. Regeneration lag is the connectors team's problem, not the docs' problem. |
+| **Generated `catalog.json` vs live `/v1/providers`** | Deployment lag. Catalog-vs-live is a separate cheap check (no credentials needed); track it under a follow-up PR. |
+| **Live API declared shape vs actual runtime behavior** | Whether `read` actually works requires sandbox accounts, installations, and real provider credentials. That is a separate program, not a docs-repo check. |
+| **Object-name drift between guides and connector source** | Requires parsing Go. Deferred to a later PR that adds `connectors.ts`. |
+| **Provider public-doc drift** | Comparing guide steps against the provider's own developer documentation requires per-provider HTML parsing. |
+| **Provider product-UI drift** | Validating screenshots and GIFs against live provider dashboards requires real accounts and MFA. Manual surface. |
 
 ## Severity → CI behavior
 

--- a/scripts/drift-check/catalog.ts
+++ b/scripts/drift-check/catalog.ts
@@ -1,0 +1,83 @@
+const CATALOG_URL =
+  'https://raw.githubusercontent.com/amp-labs/connectors/main/internal/generated/catalog.json';
+
+export type Capability = 'read' | 'write' | 'proxy' | 'subscribe';
+
+interface SupportFlags {
+  read?: boolean;
+  write?: boolean;
+  proxy?: boolean;
+  subscribe?: boolean;
+}
+
+interface ModuleEntry {
+  baseURL?: string;
+  displayName?: string;
+  support?: SupportFlags;
+}
+
+export interface CatalogProvider {
+  name?: string;
+  displayName?: string;
+  authType?: string;
+  baseURL?: string;
+  defaultModule?: string;
+  support?: SupportFlags;
+  modules?: Record<string, ModuleEntry>;
+}
+
+export interface Catalog {
+  data: Record<string, CatalogProvider>;
+  sourceUrl: string;
+  fetchedAt: string;
+}
+
+export async function fetchCatalog(): Promise<Catalog> {
+  const res = await fetch(CATALOG_URL);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch catalog: ${res.status} ${res.statusText}`);
+  }
+  const json = (await res.json()) as { catalog: Record<string, CatalogProvider> };
+  return {
+    data: json.catalog,
+    sourceUrl: CATALOG_URL,
+    fetchedAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Module-aware capability check.
+ *
+ * Returns true if either the provider-level flag is true, or any module-level
+ * flag is true. This is permissive: a guide that claims support without
+ * specifying a module is considered correct as long as some part of the
+ * provider supports it. Tightening to require module-specific claims is a
+ * PR 3 concern.
+ */
+export function supports(
+  provider: CatalogProvider | undefined,
+  capability: Capability,
+): boolean {
+  if (!provider) return false;
+  if (provider.support?.[capability]) return true;
+  for (const mod of Object.values(provider.modules ?? {})) {
+    if (mod.support?.[capability]) return true;
+  }
+  return false;
+}
+
+/** True if the provider has any module entries. */
+export function hasModules(provider: CatalogProvider | undefined): boolean {
+  return !!provider?.modules && Object.keys(provider.modules).length > 0;
+}
+
+/** Lists modules that support the given capability. Useful for advisory output. */
+export function modulesSupporting(
+  provider: CatalogProvider | undefined,
+  capability: Capability,
+): string[] {
+  if (!provider?.modules) return [];
+  return Object.entries(provider.modules)
+    .filter(([, mod]) => mod.support?.[capability])
+    .map(([name]) => name);
+}

--- a/scripts/drift-check/catalog.ts
+++ b/scripts/drift-check/catalog.ts
@@ -50,24 +50,18 @@ export async function fetchCatalog(): Promise<Catalog> {
   };
 }
 
-/**
- * Module-aware capability check.
- *
- * Returns true if either the provider-level flag is true, or any module-level
- * flag is true. This is permissive: a guide that claims support without
- * specifying a module is considered correct as long as some part of the
- * provider supports it. Tightening to require module-specific claims is a
- * PR 3 concern.
- */
+// Module-aware: returns true if the provider-level flag is true, or any
+// module-level flag is true. Catches cases like Google, where the provider
+// has subscribe=false but modules.gmail has subscribe=true.
 export function supports(
   provider: CatalogProvider | undefined,
   capability: Capability,
 ): boolean {
   if (!provider) return false;
   if (capability === 'search') {
-    if (hasAnySearchOperator(provider.support?.search)) return true;
+    if (supportsSearch(provider.support?.search)) return true;
     for (const mod of Object.values(provider.modules ?? {})) {
-      if (hasAnySearchOperator(mod.support?.search)) return true;
+      if (supportsSearch(mod.support?.search)) return true;
     }
     return false;
   }
@@ -78,17 +72,15 @@ export function supports(
   return false;
 }
 
-function hasAnySearchOperator(s: SearchSupport | undefined): boolean {
+function supportsSearch(s: SearchSupport | undefined): boolean {
   if (!s?.operators) return false;
   return Object.values(s.operators).some(Boolean);
 }
 
-/** True if the provider has any module entries. */
 export function hasModules(provider: CatalogProvider | undefined): boolean {
   return !!provider?.modules && Object.keys(provider.modules).length > 0;
 }
 
-/** Lists modules that support the given capability. Useful for advisory output. */
 export function modulesSupporting(
   provider: CatalogProvider | undefined,
   capability: Capability,
@@ -96,7 +88,7 @@ export function modulesSupporting(
   if (!provider?.modules) return [];
   if (capability === 'search') {
     return Object.entries(provider.modules)
-      .filter(([, mod]) => hasAnySearchOperator(mod.support?.search))
+      .filter(([, mod]) => supportsSearch(mod.support?.search))
       .map(([name]) => name);
   }
   return Object.entries(provider.modules)

--- a/scripts/drift-check/catalog.ts
+++ b/scripts/drift-check/catalog.ts
@@ -1,13 +1,18 @@
 const CATALOG_URL =
   'https://raw.githubusercontent.com/amp-labs/connectors/main/internal/generated/catalog.json';
 
-export type Capability = 'read' | 'write' | 'proxy' | 'subscribe';
+export type Capability = 'read' | 'write' | 'proxy' | 'subscribe' | 'search';
+
+interface SearchSupport {
+  operators?: Record<string, boolean>;
+}
 
 interface SupportFlags {
   read?: boolean;
   write?: boolean;
   proxy?: boolean;
   subscribe?: boolean;
+  search?: SearchSupport;
 }
 
 interface ModuleEntry {
@@ -59,11 +64,23 @@ export function supports(
   capability: Capability,
 ): boolean {
   if (!provider) return false;
+  if (capability === 'search') {
+    if (hasAnySearchOperator(provider.support?.search)) return true;
+    for (const mod of Object.values(provider.modules ?? {})) {
+      if (hasAnySearchOperator(mod.support?.search)) return true;
+    }
+    return false;
+  }
   if (provider.support?.[capability]) return true;
   for (const mod of Object.values(provider.modules ?? {})) {
     if (mod.support?.[capability]) return true;
   }
   return false;
+}
+
+function hasAnySearchOperator(s: SearchSupport | undefined): boolean {
+  if (!s?.operators) return false;
+  return Object.values(s.operators).some(Boolean);
 }
 
 /** True if the provider has any module entries. */
@@ -77,6 +94,11 @@ export function modulesSupporting(
   capability: Capability,
 ): string[] {
   if (!provider?.modules) return [];
+  if (capability === 'search') {
+    return Object.entries(provider.modules)
+      .filter(([, mod]) => hasAnySearchOperator(mod.support?.search))
+      .map(([name]) => name);
+  }
   return Object.entries(provider.modules)
     .filter(([, mod]) => mod.support?.[capability])
     .map(([name]) => name);

--- a/scripts/drift-check/docs.ts
+++ b/scripts/drift-check/docs.ts
@@ -1,0 +1,86 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import matter from 'gray-matter';
+
+const PROVIDER_GUIDES_DIR = path.join(process.cwd(), 'src', 'provider-guides');
+
+// Files in src/provider-guides/ that are not provider guides.
+const NON_GUIDE_FILES = new Set(['overview.mdx', 'AGENTS.md', 'CLAUDE.md']);
+
+export type Capability = 'read' | 'write' | 'proxy' | 'subscribe';
+
+export interface GuideDoc {
+  docPath: string;            // path relative to repo root
+  slug: string;               // filename without .mdx
+  providerKeyFromFrontmatter?: string;
+  guideType?: string;
+  claimedActions: Set<Capability>;
+  sampleLink?: string;        // first samples link found, if any
+}
+
+/** Fixed link patterns used in provider guides. */
+const ACTION_PATTERNS: Array<{ cap: Capability; re: RegExp }> = [
+  { cap: 'read', re: /\[Read Actions\]\(\/read-actions\)/ },
+  { cap: 'write', re: /\[Write Actions\]\(\/write-actions\)/ },
+  { cap: 'subscribe', re: /\[Subscribe Actions\]\(\/subscribe-actions\)/ },
+  { cap: 'proxy', re: /\[Proxy Actions\]\(\/proxy-actions\)/ },
+];
+
+const SAMPLE_LINK_RE =
+  /https:\/\/github\.com\/amp-labs\/samples\/blob\/[^/]+\/([^/]+)\/amp\.yaml/;
+
+export async function scanGuides(): Promise<GuideDoc[]> {
+  const entries = await fs.readdir(PROVIDER_GUIDES_DIR);
+  const guides: GuideDoc[] = [];
+  for (const entry of entries) {
+    if (!entry.endsWith('.mdx')) continue;
+    if (NON_GUIDE_FILES.has(entry)) continue;
+    const full = path.join(PROVIDER_GUIDES_DIR, entry);
+    const raw = await fs.readFile(full, 'utf8');
+    const parsed = matter(raw);
+    const slug = entry.replace(/\.mdx$/, '');
+    const claimedActions = new Set<Capability>();
+    for (const { cap, re } of ACTION_PATTERNS) {
+      if (re.test(parsed.content)) claimedActions.add(cap);
+    }
+    const sampleMatch = parsed.content.match(SAMPLE_LINK_RE);
+    guides.push({
+      docPath: path.relative(process.cwd(), full),
+      slug,
+      providerKeyFromFrontmatter:
+        typeof parsed.data.provider === 'string' ? parsed.data.provider : undefined,
+      guideType:
+        typeof parsed.data.guide_type === 'string' ? parsed.data.guide_type : undefined,
+      claimedActions,
+      sampleLink: sampleMatch ? sampleMatch[0] : undefined,
+    });
+  }
+  return guides;
+}
+
+/**
+ * Resolve the catalog provider key a guide documents.
+ *
+ * Priority:
+ *   1. frontmatter `provider` field (case preserved)
+ *   2. slugOverrides recipe
+ *   3. case-insensitive match against catalog keys (handles the systemic
+ *      "doc files lowercase, catalog mixed-case" convention split, e.g.
+ *      aweber.mdx -> aWeber)
+ *   4. filename slug verbatim (will surface as guide-without-catalog-entry
+ *      if not in catalog)
+ */
+export function resolveProviderKey(
+  guide: GuideDoc,
+  slugOverrides: Record<string, string>,
+  catalogKeys?: readonly string[],
+): string {
+  if (guide.providerKeyFromFrontmatter) return guide.providerKeyFromFrontmatter;
+  if (slugOverrides[guide.slug]) return slugOverrides[guide.slug];
+  if (catalogKeys) {
+    const ci = guide.slug.toLowerCase();
+    const match = catalogKeys.find((k) => k.toLowerCase() === ci);
+    if (match) return match;
+  }
+  return guide.slug;
+}

--- a/scripts/drift-check/docs.ts
+++ b/scripts/drift-check/docs.ts
@@ -7,7 +7,7 @@ const PROVIDER_GUIDES_DIR = path.join(process.cwd(), 'src', 'provider-guides');
 // Files in src/provider-guides/ that are not provider guides.
 const NON_GUIDE_FILES = new Set(['overview.mdx', 'AGENTS.md', 'CLAUDE.md']);
 
-export type Capability = 'read' | 'write' | 'proxy' | 'subscribe';
+export type Capability = 'read' | 'write' | 'proxy' | 'subscribe' | 'search';
 
 export interface GuideDoc {
   docPath: string;            // path relative to repo root
@@ -15,7 +15,7 @@ export interface GuideDoc {
   providerKeyFromFrontmatter?: string;
   guideType?: string;
   claimedActions: Set<Capability>;
-  sampleLink?: string;        // first samples link found, if any
+  sampleLinks: string[];      // all distinct samples links found
 }
 
 /** Fixed link patterns used in provider guides. */
@@ -24,10 +24,12 @@ const ACTION_PATTERNS: Array<{ cap: Capability; re: RegExp }> = [
   { cap: 'write', re: /\[Write Actions\]\(\/write-actions\)/ },
   { cap: 'subscribe', re: /\[Subscribe Actions\]\(\/subscribe-actions\)/ },
   { cap: 'proxy', re: /\[Proxy Actions\]\(\/proxy-actions\)/ },
+  { cap: 'search', re: /\[Search Actions\]\(\/search-actions\)/ },
 ];
 
-const SAMPLE_LINK_RE =
-  /https:\/\/github\.com\/amp-labs\/samples\/blob\/[^/]+\/([^/]+)\/amp\.yaml/;
+// Match every distinct samples link, allowing both amp.yaml and amp.yml.
+const SAMPLE_LINK_RE_G =
+  /https:\/\/github\.com\/amp-labs\/samples\/blob\/[^/]+\/[^/]+\/amp\.ya?ml/g;
 
 export async function scanGuides(): Promise<GuideDoc[]> {
   const entries = await fs.readdir(PROVIDER_GUIDES_DIR);
@@ -43,7 +45,9 @@ export async function scanGuides(): Promise<GuideDoc[]> {
     for (const { cap, re } of ACTION_PATTERNS) {
       if (re.test(parsed.content)) claimedActions.add(cap);
     }
-    const sampleMatch = parsed.content.match(SAMPLE_LINK_RE);
+    const sampleLinks = Array.from(
+      new Set(parsed.content.match(SAMPLE_LINK_RE_G) ?? []),
+    );
     guides.push({
       docPath: path.relative(process.cwd(), full),
       slug,
@@ -52,7 +56,7 @@ export async function scanGuides(): Promise<GuideDoc[]> {
       guideType:
         typeof parsed.data.guide_type === 'string' ? parsed.data.guide_type : undefined,
       claimedActions,
-      sampleLink: sampleMatch ? sampleMatch[0] : undefined,
+      sampleLinks,
     });
   }
   return guides;

--- a/scripts/drift-check/docs.ts
+++ b/scripts/drift-check/docs.ts
@@ -10,15 +10,14 @@ const NON_GUIDE_FILES = new Set(['overview.mdx', 'AGENTS.md', 'CLAUDE.md']);
 export type Capability = 'read' | 'write' | 'proxy' | 'subscribe' | 'search';
 
 export interface GuideDoc {
-  docPath: string;            // path relative to repo root
-  slug: string;               // filename without .mdx
+  docPath: string;
+  slug: string;
   providerKeyFromFrontmatter?: string;
   guideType?: string;
   claimedActions: Set<Capability>;
-  sampleLinks: string[];      // all distinct samples links found
+  sampleLinks: string[];
 }
 
-/** Fixed link patterns used in provider guides. */
 const ACTION_PATTERNS: Array<{ cap: Capability; re: RegExp }> = [
   { cap: 'read', re: /\[Read Actions\]\(\/read-actions\)/ },
   { cap: 'write', re: /\[Write Actions\]\(\/write-actions\)/ },
@@ -27,8 +26,7 @@ const ACTION_PATTERNS: Array<{ cap: Capability; re: RegExp }> = [
   { cap: 'search', re: /\[Search Actions\]\(\/search-actions\)/ },
 ];
 
-// Match every distinct samples link, allowing both amp.yaml and amp.yml.
-const SAMPLE_LINK_RE_G =
+const SAMPLE_LINK_RE =
   /https:\/\/github\.com\/amp-labs\/samples\/blob\/[^/]+\/[^/]+\/amp\.ya?ml/g;
 
 export async function scanGuides(): Promise<GuideDoc[]> {
@@ -46,7 +44,7 @@ export async function scanGuides(): Promise<GuideDoc[]> {
       if (re.test(parsed.content)) claimedActions.add(cap);
     }
     const sampleLinks = Array.from(
-      new Set(parsed.content.match(SAMPLE_LINK_RE_G) ?? []),
+      new Set(parsed.content.match(SAMPLE_LINK_RE) ?? []),
     );
     guides.push({
       docPath: path.relative(process.cwd(), full),
@@ -62,18 +60,8 @@ export async function scanGuides(): Promise<GuideDoc[]> {
   return guides;
 }
 
-/**
- * Resolve the catalog provider key a guide documents.
- *
- * Priority:
- *   1. frontmatter `provider` field (case preserved)
- *   2. slugOverrides recipe
- *   3. case-insensitive match against catalog keys (handles the systemic
- *      "doc files lowercase, catalog mixed-case" convention split, e.g.
- *      aweber.mdx -> aWeber)
- *   4. filename slug verbatim (will surface as guide-without-catalog-entry
- *      if not in catalog)
- */
+// Resolution priority: frontmatter `provider` > slugOverrides > case-insensitive
+// match against catalog keys > filename slug verbatim.
 export function resolveProviderKey(
   guide: GuideDoc,
   slugOverrides: Record<string, string>,

--- a/scripts/drift-check/index.ts
+++ b/scripts/drift-check/index.ts
@@ -1,0 +1,174 @@
+#!/usr/bin/env tsx
+/**
+ * Drift check v1.
+ *
+ * Static comparison of provider guides against the connectors catalog.
+ * Three checks:
+ *   - undocumented-provider: catalog has a provider with no guide and no
+ *     allowance in recipes.ts
+ *   - doc-overclaims-<capability>: guide claims an action the catalog
+ *     (module-aware) does not support
+ *   - broken-sample-link: guide links to a sample manifest that 404s
+ *
+ * Modes:
+ *   --mode full          scan every provider guide (default)
+ *   --mode per-pr        scan only .mdx files passed via --changed
+ *   --mode provider      scan a single provider via --provider <key>
+ *
+ * Output:
+ *   --out <dir>          write drift-report.json and drift-report.md
+ *                        (default ./drift-report)
+ */
+import { parseArgs } from 'node:util';
+import path from 'node:path';
+import {
+  fetchCatalog,
+  supports,
+  modulesSupporting,
+  type Capability,
+} from './catalog';
+import { scanGuides, resolveProviderKey, type GuideDoc } from './docs';
+import { checkSampleLink } from './samples';
+import { recipes } from './recipes';
+import { writeReport, type Finding, type Report } from './report';
+
+async function main() {
+  const { values } = parseArgs({
+    options: {
+      mode: { type: 'string', default: 'full' },
+      provider: { type: 'string' },
+      changed: { type: 'string', multiple: true },
+      out: { type: 'string', default: './drift-report' },
+      'fail-on-error': { type: 'boolean', default: false },
+    },
+  });
+
+  const mode = values.mode as 'full' | 'per-pr' | 'provider';
+
+  const catalog = await fetchCatalog();
+  const catalogKeys = Object.keys(catalog.data);
+  let guides = await scanGuides();
+
+  if (mode === 'per-pr') {
+    const changedSet = new Set((values.changed ?? []).map((p) => path.normalize(p)));
+    guides = guides.filter((g) => changedSet.has(path.normalize(g.docPath)));
+  } else if (mode === 'provider') {
+    if (!values.provider) {
+      throw new Error('--provider <key> required with --mode provider');
+    }
+    guides = guides.filter(
+      (g) =>
+        resolveProviderKey(g, recipes.slugOverrides, catalogKeys) === values.provider,
+    );
+  }
+
+  const findings: Finding[] = [];
+
+  // Check: undocumented providers. Full mode only; otherwise the per-PR slice
+  // can't tell what's missing.
+  if (mode === 'full') {
+    const documentedKeys = new Set(
+      (await scanGuides()).map((g) => resolveProviderKey(g, recipes.slugOverrides, catalogKeys)),
+    );
+    const today = new Date();
+    for (const catalogKey of Object.keys(catalog.data)) {
+      if (documentedKeys.has(catalogKey)) continue;
+      const allow = recipes.undocumentedAllowed.find((a) => a.provider === catalogKey);
+      if (allow) {
+        if (new Date(allow.until) < today) {
+          findings.push({
+            provider: catalogKey,
+            severity: 'warning',
+            kind: 'undocumented-provider-allowance-expired',
+            suggestedFix: `Renew or remove the allowance for "${catalogKey}" in scripts/drift-check/recipes.ts (current until=${allow.until}).`,
+          });
+        }
+        continue;
+      }
+      findings.push({
+        provider: catalogKey,
+        severity: 'error',
+        kind: 'undocumented-provider',
+        suggestedFix: `Add a provider guide at src/provider-guides/${catalogKey}.mdx, or add "${catalogKey}" to undocumentedAllowed in scripts/drift-check/recipes.ts with a reason and an "until" date.`,
+      });
+    }
+  }
+
+  // Check: doc-overclaims-<capability> + collect sample-link checks.
+  const sampleChecks: Promise<void>[] = [];
+  for (const guide of guides) {
+    const providerKey = resolveProviderKey(guide, recipes.slugOverrides, catalogKeys);
+    const cp = catalog.data[providerKey];
+    if (!cp) {
+      findings.push({
+        provider: providerKey,
+        severity: 'error',
+        kind: 'guide-without-catalog-entry',
+        docPath: guide.docPath,
+        suggestedFix: `The guide resolves to provider key "${providerKey}" but the catalog has no such entry. Check the frontmatter "provider" field or add a slugOverride in recipes.ts.`,
+      });
+      continue;
+    }
+    for (const cap of guide.claimedActions) {
+      if (!supports(cp, cap as Capability)) {
+        findings.push({
+          provider: providerKey,
+          severity: 'error',
+          kind: `doc-overclaims-${cap}`,
+          docPath: guide.docPath,
+          docClaim: `Guide includes "[${capitalize(cap)} Actions](/${cap}-actions)".`,
+          catalogTruth: {
+            providerLevel: cp.support?.[cap as Capability] ?? false,
+            modulesSupporting: modulesSupporting(cp, cap as Capability),
+          },
+          suggestedFix: `Remove the ${cap} action claim, or update the connector if support was added but not flagged.`,
+        });
+      }
+    }
+    if (guide.sampleLink) {
+      sampleChecks.push(
+        checkSampleLink(guide.sampleLink).then((r) => {
+          if (!r.exists) {
+            findings.push({
+              provider: providerKey,
+              severity: 'error',
+              kind: 'broken-sample-link',
+              docPath: guide.docPath,
+              docClaim: r.url,
+              catalogTruth: { httpStatus: r.status ?? 'fetch failed' },
+              suggestedFix: `Update or remove the sample link. The referenced file does not exist at ${r.url}.`,
+            });
+          }
+        }),
+      );
+    }
+  }
+  await Promise.all(sampleChecks);
+
+  const report: Report = {
+    catalogSource: `${catalog.sourceUrl} (fetched from amp-labs/connectors@main)`,
+    checkedAt: catalog.fetchedAt,
+    mode,
+    findings,
+  };
+  await writeReport(report, values.out!);
+
+  const errorCount = findings.filter((f) => f.severity === 'error').length;
+  console.log(
+    `\n${findings.length} findings (${errorCount} error, ${
+      findings.filter((f) => f.severity === 'warning').length
+    } warning, ${findings.filter((f) => f.severity === 'info').length} info).`,
+  );
+  if (values['fail-on-error'] && errorCount > 0) {
+    process.exit(1);
+  }
+}
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(2);
+});

--- a/scripts/drift-check/index.ts
+++ b/scripts/drift-check/index.ts
@@ -23,9 +23,11 @@ import { parseArgs } from 'node:util';
 import path from 'node:path';
 import {
   fetchCatalog,
+  hasModules,
   supports,
   modulesSupporting,
   type Capability,
+  type CatalogProvider,
 } from './catalog';
 import { scanGuides, resolveProviderKey, type GuideDoc } from './docs';
 import { checkSampleLink } from './samples';
@@ -33,7 +35,12 @@ import { recipes } from './recipes';
 import { writeReport, type Finding, type Report } from './report';
 
 async function main() {
+  // Accept both `drift-check --out X` and `pnpm run drift-check -- --out X`
+  // by stripping a leading `--` separator if present.
+  const args = process.argv.slice(2);
+  if (args[0] === '--') args.shift();
   const { values } = parseArgs({
+    args,
     options: {
       mode: { type: 'string', default: 'full' },
       provider: { type: 'string' },
@@ -111,33 +118,37 @@ async function main() {
     }
     for (const cap of guide.claimedActions) {
       if (!supports(cp, cap as Capability)) {
-        findings.push({
-          provider: providerKey,
-          severity: 'error',
-          kind: `doc-overclaims-${cap}`,
-          docPath: guide.docPath,
-          docClaim: `Guide includes "[${capitalize(cap)} Actions](/${cap}-actions)".`,
-          catalogTruth: {
-            providerLevel: cp.support?.[cap as Capability] ?? false,
-            modulesSupporting: modulesSupporting(cp, cap as Capability),
-          },
-          suggestedFix: `Remove the ${cap} action claim, or update the connector if support was added but not flagged.`,
-        });
+        findings.push(
+          withModule(cp, {
+            provider: providerKey,
+            severity: 'error',
+            kind: `doc-overclaims-${cap}`,
+            docPath: guide.docPath,
+            docClaim: `Guide includes "[${capitalize(cap)} Actions](/${cap}-actions)".`,
+            catalogTruth: {
+              providerLevel: capabilityValueAt(cp, cap as Capability, 'provider'),
+              modulesSupporting: modulesSupporting(cp, cap as Capability),
+            },
+            suggestedFix: `Remove the ${cap} action claim, or update the connector if support was added but not flagged.`,
+          }),
+        );
       }
     }
-    if (guide.sampleLink) {
+    for (const sampleLink of guide.sampleLinks) {
       sampleChecks.push(
-        checkSampleLink(guide.sampleLink).then((r) => {
+        checkSampleLink(sampleLink).then((r) => {
           if (!r.exists) {
-            findings.push({
-              provider: providerKey,
-              severity: 'error',
-              kind: 'broken-sample-link',
-              docPath: guide.docPath,
-              docClaim: r.url,
-              catalogTruth: { httpStatus: r.status ?? 'fetch failed' },
-              suggestedFix: `Update or remove the sample link. The referenced file does not exist at ${r.url}.`,
-            });
+            findings.push(
+              withModule(cp, {
+                provider: providerKey,
+                severity: 'error',
+                kind: 'broken-sample-link',
+                docPath: guide.docPath,
+                docClaim: r.url,
+                catalogTruth: { httpStatus: r.status ?? 'fetch failed' },
+                suggestedFix: `Update or remove the sample link. The referenced file does not exist at ${r.url}.`,
+              }),
+            );
           }
         }),
       );
@@ -166,6 +177,31 @@ async function main() {
 
 function capitalize(s: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+/**
+ * Enforce the module-aware schema: if the provider has modules and the
+ * finding does not specify one, default to "all". Single-module providers
+ * leave module unset.
+ */
+function withModule(
+  provider: CatalogProvider | undefined,
+  finding: Finding,
+): Finding {
+  if (finding.module !== undefined) return finding;
+  if (provider && hasModules(provider)) {
+    return { ...finding, module: 'all' };
+  }
+  return finding;
+}
+
+function capabilityValueAt(
+  cp: CatalogProvider,
+  cap: Capability,
+  _level: 'provider',
+): unknown {
+  if (cap === 'search') return cp.support?.search ?? false;
+  return cp.support?.[cap] ?? false;
 }
 
 main().catch((err) => {

--- a/scripts/drift-check/index.ts
+++ b/scripts/drift-check/index.ts
@@ -1,24 +1,4 @@
 #!/usr/bin/env tsx
-/**
- * Drift check v1.
- *
- * Static comparison of provider guides against the connectors catalog.
- * Three checks:
- *   - undocumented-provider: catalog has a provider with no guide and no
- *     allowance in recipes.ts
- *   - doc-overclaims-<capability>: guide claims an action the catalog
- *     (module-aware) does not support
- *   - broken-sample-link: guide links to a sample manifest that 404s
- *
- * Modes:
- *   --mode full          scan every provider guide (default)
- *   --mode per-pr        scan only .mdx files passed via --changed
- *   --mode provider      scan a single provider via --provider <key>
- *
- * Output:
- *   --out <dir>          write drift-report.json and drift-report.md
- *                        (default ./drift-report)
- */
 import { parseArgs } from 'node:util';
 import path from 'node:path';
 import {
@@ -29,14 +9,13 @@ import {
   type Capability,
   type CatalogProvider,
 } from './catalog';
-import { scanGuides, resolveProviderKey, type GuideDoc } from './docs';
+import { scanGuides, resolveProviderKey } from './docs';
 import { checkSampleLink } from './samples';
 import { recipes } from './recipes';
 import { writeReport, type Finding, type Report } from './report';
 
 async function main() {
-  // Accept both `drift-check --out X` and `pnpm run drift-check -- --out X`
-  // by stripping a leading `--` separator if present.
+  // Accept both `drift-check --out X` and `pnpm run drift-check -- --out X`.
   const args = process.argv.slice(2);
   if (args[0] === '--') args.shift();
   const { values } = parseArgs({
@@ -71,14 +50,13 @@ async function main() {
 
   const findings: Finding[] = [];
 
-  // Check: undocumented providers. Full mode only; otherwise the per-PR slice
-  // can't tell what's missing.
+  // The undocumented-provider check requires a global view, so it only runs in full mode.
   if (mode === 'full') {
     const documentedKeys = new Set(
-      (await scanGuides()).map((g) => resolveProviderKey(g, recipes.slugOverrides, catalogKeys)),
+      guides.map((g) => resolveProviderKey(g, recipes.slugOverrides, catalogKeys)),
     );
     const today = new Date();
-    for (const catalogKey of Object.keys(catalog.data)) {
+    for (const catalogKey of catalogKeys) {
       if (documentedKeys.has(catalogKey)) continue;
       const allow = recipes.undocumentedAllowed.find((a) => a.provider === catalogKey);
       if (allow) {
@@ -101,12 +79,11 @@ async function main() {
     }
   }
 
-  // Check: doc-overclaims-<capability> + collect sample-link checks.
   const sampleChecks: Promise<void>[] = [];
   for (const guide of guides) {
     const providerKey = resolveProviderKey(guide, recipes.slugOverrides, catalogKeys);
-    const cp = catalog.data[providerKey];
-    if (!cp) {
+    const provider = catalog.data[providerKey];
+    if (!provider) {
       findings.push({
         provider: providerKey,
         severity: 'error',
@@ -117,17 +94,17 @@ async function main() {
       continue;
     }
     for (const cap of guide.claimedActions) {
-      if (!supports(cp, cap as Capability)) {
+      if (!supports(provider, cap as Capability)) {
         findings.push(
-          withModule(cp, {
+          withModule(provider, {
             provider: providerKey,
             severity: 'error',
             kind: `doc-overclaims-${cap}`,
             docPath: guide.docPath,
             docClaim: `Guide includes "[${capitalize(cap)} Actions](/${cap}-actions)".`,
             catalogTruth: {
-              providerLevel: capabilityValueAt(cp, cap as Capability, 'provider'),
-              modulesSupporting: modulesSupporting(cp, cap as Capability),
+              providerLevel: providerLevelSupport(provider, cap as Capability),
+              modulesSupporting: modulesSupporting(provider, cap as Capability),
             },
             suggestedFix: `Remove the ${cap} action claim, or update the connector if support was added but not flagged.`,
           }),
@@ -139,7 +116,7 @@ async function main() {
         checkSampleLink(sampleLink).then((r) => {
           if (!r.exists) {
             findings.push(
-              withModule(cp, {
+              withModule(provider, {
                 provider: providerKey,
                 severity: 'error',
                 kind: 'broken-sample-link',
@@ -179,29 +156,16 @@ function capitalize(s: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1);
 }
 
-/**
- * Enforce the module-aware schema: if the provider has modules and the
- * finding does not specify one, default to "all". Single-module providers
- * leave module unset.
- */
-function withModule(
-  provider: CatalogProvider | undefined,
-  finding: Finding,
-): Finding {
+// Default module to "all" on findings for multi-module providers; v1 does not attribute claims to a specific module.
+function withModule(provider: CatalogProvider, finding: Finding): Finding {
   if (finding.module !== undefined) return finding;
-  if (provider && hasModules(provider)) {
-    return { ...finding, module: 'all' };
-  }
+  if (hasModules(provider)) return { ...finding, module: 'all' };
   return finding;
 }
 
-function capabilityValueAt(
-  cp: CatalogProvider,
-  cap: Capability,
-  _level: 'provider',
-): unknown {
-  if (cap === 'search') return cp.support?.search ?? false;
-  return cp.support?.[cap] ?? false;
+function providerLevelSupport(provider: CatalogProvider, cap: Capability): unknown {
+  if (cap === 'search') return provider.support?.search ?? false;
+  return provider.support?.[cap] ?? false;
 }
 
 main().catch((err) => {

--- a/scripts/drift-check/recipes.ts
+++ b/scripts/drift-check/recipes.ts
@@ -34,6 +34,11 @@ export const recipes: Recipes = {
     },
     { provider: 'adyenTest', reason: 'Internal test variant.', until: '2027-01-01' },
     { provider: 'gladlyQA', reason: 'QA-only variant.', until: '2027-01-01' },
+    {
+      provider: 'docusignDeveloper',
+      reason: 'Developer-environment variant; setup covered by docusign.mdx.',
+      until: '2026-09-01',
+    },
     { provider: 'deelSandbox', reason: 'Sandbox variant.', until: '2027-01-01' },
     { provider: 'gustoDemo', reason: 'Demo variant.', until: '2027-01-01' },
     { provider: 'paddleSandbox', reason: 'Sandbox variant.', until: '2027-01-01' },

--- a/scripts/drift-check/recipes.ts
+++ b/scripts/drift-check/recipes.ts
@@ -69,7 +69,7 @@ export const recipes: Recipes = {
       until: '2027-01-01',
     },
     {
-      provider: 'paypalSandbox',
+      provider: 'payPalSandBox',
       reason: 'Sandbox variant.',
       until: '2027-01-01',
     },

--- a/scripts/drift-check/recipes.ts
+++ b/scripts/drift-check/recipes.ts
@@ -1,39 +1,28 @@
-// Sparse overrides and allowances for the drift check.
-// Only encode exceptions here. Every other case should be conventional.
+// Sparse overrides and allowances. Only encode exceptions here; convention covers the rest.
 
 export interface UndocumentedAllowance {
-  provider: string;     // exact catalog key
+  provider: string;
   reason: string;
-  until: string;        // ISO date; allowance expires after this
+  until: string;   // ISO date; allowance expires after this
 }
 
 export interface Recipes {
-  // Maps a doc file slug (filename without .mdx) to the catalog provider key
-  // when they differ. Use only when the conventional `<provider>.mdx` lookup
-  // does not apply.
   slugOverrides: Record<string, string>;
-
-  // Catalog provider keys that are intentionally undocumented. Anything not
-  // listed here that lacks a guide will produce an `undocumented-provider`
-  // error finding.
   undocumentedAllowed: UndocumentedAllowance[];
 }
 
 export const recipes: Recipes = {
   slugOverrides: {
-    // The instantly.mdx guide currently documents the instantlyAI catalog
-    // entry (V2 API). The instantly catalog entry (Legacy V1) is allowed
-    // undocumented below.
+    // instantly.mdx documents the V2 catalog entry (instantlyAI); the V1 entry
+    // is allowed undocumented below.
     instantly: 'instantlyAI',
-    // Filename uses hyphens; catalog keys are camelCase without hyphens.
     'google-workspace-delegation': 'googleWorkspaceDelegation',
     'netsuite-m2m': 'netsuiteM2M',
     'salesforce-jwt': 'salesforceJWT',
-    // jira.mdx is an alias guide that points readers to the Atlassian guide.
-    // Mapping it to atlassian lets it inherit the same catalog-side checks.
+    // jira.mdx is an alias guide pointing readers to the Atlassian guide.
     jira: 'atlassian',
-    // highlevel.mdx documents the Standard variant; the WhiteLabel variant
-    // is intentionally undocumented (see undocumentedAllowed below).
+    // highlevel.mdx covers the Standard variant; the WhiteLabel variant is
+    // allowed undocumented below.
     highlevel: 'highLevelStandard',
   },
 
@@ -43,64 +32,20 @@ export const recipes: Recipes = {
       reason: 'Legacy V1 connector; current public guide covers instantlyAI.',
       until: '2026-09-01',
     },
-    {
-      provider: 'adyenTest',
-      reason: 'Internal test variant; not user-facing.',
-      until: '2027-01-01',
-    },
-    {
-      provider: 'gladlyQA',
-      reason: 'QA-only variant of gladly; not user-facing.',
-      until: '2027-01-01',
-    },
-    {
-      provider: 'deelSandbox',
-      reason: 'Sandbox variant; share docs with deel.',
-      until: '2027-01-01',
-    },
-    {
-      provider: 'gustoDemo',
-      reason: 'Demo variant; share docs with gusto.',
-      until: '2027-01-01',
-    },
-    {
-      provider: 'paddleSandbox',
-      reason: 'Sandbox variant.',
-      until: '2027-01-01',
-    },
-    {
-      provider: 'payPalSandBox',
-      reason: 'Sandbox variant.',
-      until: '2027-01-01',
-    },
-    {
-      provider: 'procoreSandbox',
-      reason: 'Sandbox variant.',
-      until: '2027-01-01',
-    },
-    {
-      provider: 'quickbooksSandbox',
-      reason: 'Sandbox variant.',
-      until: '2027-01-01',
-    },
-    {
-      provider: 'rampDemo',
-      reason: 'Demo variant.',
-      until: '2027-01-01',
-    },
-    {
-      provider: 'ironcladDemo',
-      reason: 'Demo variant.',
-      until: '2027-01-01',
-    },
-    {
-      provider: 'leverSandbox',
-      reason: 'Sandbox variant.',
-      until: '2027-01-01',
-    },
+    { provider: 'adyenTest', reason: 'Internal test variant.', until: '2027-01-01' },
+    { provider: 'gladlyQA', reason: 'QA-only variant.', until: '2027-01-01' },
+    { provider: 'deelSandbox', reason: 'Sandbox variant.', until: '2027-01-01' },
+    { provider: 'gustoDemo', reason: 'Demo variant.', until: '2027-01-01' },
+    { provider: 'paddleSandbox', reason: 'Sandbox variant.', until: '2027-01-01' },
+    { provider: 'payPalSandBox', reason: 'Sandbox variant.', until: '2027-01-01' },
+    { provider: 'procoreSandbox', reason: 'Sandbox variant.', until: '2027-01-01' },
+    { provider: 'quickbooksSandbox', reason: 'Sandbox variant.', until: '2027-01-01' },
+    { provider: 'rampDemo', reason: 'Demo variant.', until: '2027-01-01' },
+    { provider: 'ironcladDemo', reason: 'Demo variant.', until: '2027-01-01' },
+    { provider: 'leverSandbox', reason: 'Sandbox variant.', until: '2027-01-01' },
     {
       provider: 'highLevelWhiteLabel',
-      reason: 'WhiteLabel variant; the highlevel.mdx guide covers the Standard variant.',
+      reason: 'WhiteLabel variant; highlevel.mdx covers the Standard variant.',
       until: '2026-09-01',
     },
   ],

--- a/scripts/drift-check/recipes.ts
+++ b/scripts/drift-check/recipes.ts
@@ -1,0 +1,107 @@
+// Sparse overrides and allowances for the drift check.
+// Only encode exceptions here. Every other case should be conventional.
+
+export interface UndocumentedAllowance {
+  provider: string;     // exact catalog key
+  reason: string;
+  until: string;        // ISO date; allowance expires after this
+}
+
+export interface Recipes {
+  // Maps a doc file slug (filename without .mdx) to the catalog provider key
+  // when they differ. Use only when the conventional `<provider>.mdx` lookup
+  // does not apply.
+  slugOverrides: Record<string, string>;
+
+  // Catalog provider keys that are intentionally undocumented. Anything not
+  // listed here that lacks a guide will produce an `undocumented-provider`
+  // error finding.
+  undocumentedAllowed: UndocumentedAllowance[];
+}
+
+export const recipes: Recipes = {
+  slugOverrides: {
+    // The instantly.mdx guide currently documents the instantlyAI catalog
+    // entry (V2 API). The instantly catalog entry (Legacy V1) is allowed
+    // undocumented below.
+    instantly: 'instantlyAI',
+    // Filename uses hyphens; catalog keys are camelCase without hyphens.
+    'google-workspace-delegation': 'googleWorkspaceDelegation',
+    'netsuite-m2m': 'netsuiteM2M',
+    'salesforce-jwt': 'salesforceJWT',
+    // jira.mdx is an alias guide that points readers to the Atlassian guide.
+    // Mapping it to atlassian lets it inherit the same catalog-side checks.
+    jira: 'atlassian',
+    // highlevel.mdx documents the Standard variant; the WhiteLabel variant
+    // is intentionally undocumented (see undocumentedAllowed below).
+    highlevel: 'highLevelStandard',
+  },
+
+  undocumentedAllowed: [
+    {
+      provider: 'instantly',
+      reason: 'Legacy V1 connector; current public guide covers instantlyAI.',
+      until: '2026-09-01',
+    },
+    {
+      provider: 'adyenTest',
+      reason: 'Internal test variant; not user-facing.',
+      until: '2027-01-01',
+    },
+    {
+      provider: 'gladlyQA',
+      reason: 'QA-only variant of gladly; not user-facing.',
+      until: '2027-01-01',
+    },
+    {
+      provider: 'deelSandbox',
+      reason: 'Sandbox variant; share docs with deel.',
+      until: '2027-01-01',
+    },
+    {
+      provider: 'gustoDemo',
+      reason: 'Demo variant; share docs with gusto.',
+      until: '2027-01-01',
+    },
+    {
+      provider: 'paddleSandbox',
+      reason: 'Sandbox variant.',
+      until: '2027-01-01',
+    },
+    {
+      provider: 'paypalSandbox',
+      reason: 'Sandbox variant.',
+      until: '2027-01-01',
+    },
+    {
+      provider: 'procoreSandbox',
+      reason: 'Sandbox variant.',
+      until: '2027-01-01',
+    },
+    {
+      provider: 'quickbooksSandbox',
+      reason: 'Sandbox variant.',
+      until: '2027-01-01',
+    },
+    {
+      provider: 'rampDemo',
+      reason: 'Demo variant.',
+      until: '2027-01-01',
+    },
+    {
+      provider: 'ironcladDemo',
+      reason: 'Demo variant.',
+      until: '2027-01-01',
+    },
+    {
+      provider: 'leverSandbox',
+      reason: 'Sandbox variant.',
+      until: '2027-01-01',
+    },
+    {
+      provider: 'highLevelWhiteLabel',
+      reason: 'WhiteLabel variant; the highlevel.mdx guide covers the Standard variant.',
+      until: '2026-09-01',
+    },
+  ],
+};

--- a/scripts/drift-check/report.ts
+++ b/scripts/drift-check/report.ts
@@ -1,0 +1,72 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+export type Severity = 'error' | 'warning' | 'info';
+
+export interface Finding {
+  provider: string;          // exact catalog key, case preserved
+  module?: string | 'all';   // required for multi-module providers when known
+  severity: Severity;
+  kind: string;
+  docPath?: string;
+  docClaim?: string;
+  catalogTruth?: unknown;
+  suggestedFix?: string;
+}
+
+export interface Report {
+  catalogSource: string;
+  checkedAt: string;          // ISO timestamp
+  mode: 'per-pr' | 'full' | 'provider';
+  findings: Finding[];
+}
+
+export async function writeReport(report: Report, outDir: string): Promise<void> {
+  await fs.mkdir(outDir, { recursive: true });
+  const jsonPath = path.join(outDir, 'drift-report.json');
+  const mdPath = path.join(outDir, 'drift-report.md');
+  await fs.writeFile(jsonPath, JSON.stringify(report, null, 2) + '\n');
+  await fs.writeFile(mdPath, toMarkdown(report));
+  console.log(`Wrote ${jsonPath}`);
+  console.log(`Wrote ${mdPath}`);
+}
+
+function toMarkdown(report: Report): string {
+  const bySeverity: Record<Severity, Finding[]> = { error: [], warning: [], info: [] };
+  for (const f of report.findings) bySeverity[f.severity].push(f);
+
+  const lines: string[] = [];
+  lines.push('# Drift check report');
+  lines.push('');
+  lines.push(`- Catalog source: \`${report.catalogSource}\``);
+  lines.push(`- Checked at: \`${report.checkedAt}\``);
+  lines.push(`- Mode: \`${report.mode}\``);
+  lines.push(`- Totals: ${bySeverity.error.length} error, ${bySeverity.warning.length} warning, ${bySeverity.info.length} info`);
+  lines.push('');
+
+  for (const sev of ['error', 'warning', 'info'] as const) {
+    const group = bySeverity[sev];
+    if (group.length === 0) continue;
+    lines.push(`## ${capitalize(sev)} (${group.length})`);
+    lines.push('');
+    for (const f of group.sort(sortByProvider)) {
+      const mod = f.module ? ` [${f.module}]` : '';
+      lines.push(`### ${f.provider}${mod} — ${f.kind}`);
+      if (f.docPath) lines.push(`- File: \`${f.docPath}\``);
+      if (f.docClaim) lines.push(`- Doc says: ${f.docClaim}`);
+      if (f.catalogTruth !== undefined) lines.push(`- Catalog says: \`${JSON.stringify(f.catalogTruth)}\``);
+      if (f.suggestedFix) lines.push(`- Fix: ${f.suggestedFix}`);
+      lines.push('');
+    }
+  }
+  return lines.join('\n');
+}
+
+function sortByProvider(a: Finding, b: Finding): number {
+  if (a.provider !== b.provider) return a.provider.localeCompare(b.provider);
+  return (a.kind ?? '').localeCompare(b.kind ?? '');
+}
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}

--- a/scripts/drift-check/samples.ts
+++ b/scripts/drift-check/samples.ts
@@ -15,12 +15,28 @@ export interface SampleCheckResult {
   status?: number;
 }
 
+/**
+ * Trusts a 404 immediately (definitive missing). Retries once on network
+ * errors or non-404 non-2xx responses, since GitHub raw can produce
+ * transient 5xx / connection blips that would otherwise become false
+ * positives in CI.
+ */
 export async function checkSampleLink(blobUrl: string): Promise<SampleCheckResult> {
   const rawUrl = toRawUrl(blobUrl);
-  try {
-    const res = await fetch(rawUrl, { method: 'HEAD' });
-    return { url: blobUrl, exists: res.ok, status: res.status };
-  } catch {
-    return { url: blobUrl, exists: false };
+  const MAX_ATTEMPTS = 2;
+  let lastStatus: number | undefined;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      const res = await fetch(rawUrl, { method: 'HEAD' });
+      if (res.ok) return { url: blobUrl, exists: true, status: res.status };
+      if (res.status === 404) return { url: blobUrl, exists: false, status: 404 };
+      lastStatus = res.status;
+    } catch {
+      // network error; retry
+    }
+    if (attempt < MAX_ATTEMPTS) {
+      await new Promise((r) => setTimeout(r, 250 * attempt));
+    }
   }
+  return { url: blobUrl, exists: false, status: lastStatus };
 }

--- a/scripts/drift-check/samples.ts
+++ b/scripts/drift-check/samples.ts
@@ -1,0 +1,26 @@
+/**
+ * Resolve a github.com/...blob/... URL to its raw equivalent, since blob URLs
+ * return a 200 HTML page even for missing files. The raw URL returns 404 on
+ * missing files, which is what we want for existence checking.
+ */
+function toRawUrl(blobUrl: string): string {
+  return blobUrl
+    .replace('github.com/', 'raw.githubusercontent.com/')
+    .replace('/blob/', '/');
+}
+
+export interface SampleCheckResult {
+  url: string;
+  exists: boolean;
+  status?: number;
+}
+
+export async function checkSampleLink(blobUrl: string): Promise<SampleCheckResult> {
+  const rawUrl = toRawUrl(blobUrl);
+  try {
+    const res = await fetch(rawUrl, { method: 'HEAD' });
+    return { url: blobUrl, exists: res.ok, status: res.status };
+  } catch {
+    return { url: blobUrl, exists: false };
+  }
+}

--- a/scripts/drift-check/samples.ts
+++ b/scripts/drift-check/samples.ts
@@ -1,8 +1,4 @@
-/**
- * Resolve a github.com/...blob/... URL to its raw equivalent, since blob URLs
- * return a 200 HTML page even for missing files. The raw URL returns 404 on
- * missing files, which is what we want for existence checking.
- */
+// blob URLs return a 200 HTML page for missing files; raw URLs return 404.
 function toRawUrl(blobUrl: string): string {
   return blobUrl
     .replace('github.com/', 'raw.githubusercontent.com/')
@@ -15,12 +11,7 @@ export interface SampleCheckResult {
   status?: number;
 }
 
-/**
- * Trusts a 404 immediately (definitive missing). Retries once on network
- * errors or non-404 non-2xx responses, since GitHub raw can produce
- * transient 5xx / connection blips that would otherwise become false
- * positives in CI.
- */
+// Trusts 404 immediately; retries once on transient errors (5xx, network blips).
 export async function checkSampleLink(blobUrl: string): Promise<SampleCheckResult> {
   const rawUrl = toRawUrl(blobUrl);
   const MAX_ATTEMPTS = 2;


### PR DESCRIPTION
## Description

Adds a static drift-check script for provider guides. Compares provider-guide claims against the generated [`amp-labs/connectors`](https://github.com/amp-labs/connectors/blob/main/internal/generated/catalog.json) catalog and validates linked sample manifests. Writes both a machine-readable JSON report and a Markdown rollup.

**What it checks**

- Catalog providers with no provider guide and no explicit allowance
- Guides that resolve to no catalog provider
- Guide claims for Read/Write/Proxy/Subscribe/Search Actions that the catalog does not expose
- Broken `amp.yaml` / `amp.yml` sample links

The check is module-aware: a capability claim is valid if either the provider-level flag is true or any module-level flag is true. Catches cases like Google's Gmail submodule.

**What this does not prove**

Static validation only. Does not compare against the deployed `/v1/providers` API, inspect connector Go source, or run provider runtime calls. The full out-of-scope list is in [`scripts/drift-check/README.md`](./scripts/drift-check/README.md).

**Current output**

A full run on current `main` reports 37 findings:

- 29 undocumented providers
- 5 broken sample links
- 2 write-action catalog mismatches (aws, monday)
- 1 proxy-action catalog mismatch (greenhouseJobBoard)

(Initial run when the PR was opened reported 40; subsequent merges of #610 and #612, plus new provider guides for accuLynx and procore on `main`, account for the difference.)

The mismatches are intentionally left as report output rather than auto-fixed because the correct fix may live in docs, catalog metadata, connector source, or product release state. A separate triage issue will categorize the findings for follow-up.

**Verification**

```shell
pnpm run drift-check
# 37 findings (37 error, 0 warning, 0 info)
```

## Screenshot

Not applicable. This PR adds a CLI script under `scripts/` and does not modify any documentation content. `mint dev` renders the docs site identically to `main`.

