### PR TITLE
fix(zendeskSupport): correct sample manifest URL

### DIFF
--- a/src/provider-guides/zendeskSupport.mdx
+++ b/src/provider-guides/zendeskSupport.mdx
@@ -63,7 +63,7 @@ The Zendesk Support connector supports reading from and writing to the following
 
 ### Example Integration
 
-For an example manifest file of a Zendesk Support integration, visit our [samples repo on Github](https://github.com/amp-labs/samples/blob/main/zendesk-support/amp.yaml).
+For an example manifest file of a Zendesk Support integration, visit our [samples repo on Github](https://github.com/amp-labs/samples/blob/main/zendeskSupport/amp.yaml).
 
 ## Before You Get Started
 
@@ -131,7 +131,7 @@ You need a **Zendesk** account to connect with Ampersand.
 
 To start integrating with Zendesk Support:
 
-- Create a manifest file like the [example](https://github.com/amp-labs/samples/blob/main/zendesk-support/amp.yaml).
+- Create a manifest file like the [example](https://github.com/amp-labs/samples/blob/main/zendeskSupport/amp.yaml).
 - Deploy it using the [amp CLI](/cli/overview).
 - If you are using Read Actions, create a [destination](/destinations).
 - Embed the [InstallIntegration](/embeddable-ui-components#install-integration) UI component.


### PR DESCRIPTION
## Description

Fixes both sample-manifest links in `src/provider-guides/zendeskSupport.mdx`. They previously pointed at `samples/blob/main/zendesk-support/amp.yaml` (hyphenated), which returns 404. The actual sample is at `samples/blob/main/zendeskSupport/amp.yaml` (camelCase).

Both occurrences updated (line 66 in the example-integration section, line 134 in the using-the-connector section).

**Surfaced by:** the drift-check detector proposed in #608.
**Triaged in:** #609 as the lone deterministic docs fix among the seven `broken-sample-link` findings.

**Verified:** [`samples/main/zendeskSupport/amp.yaml`](https://github.com/amp-labs/samples/blob/main/zendeskSupport/amp.yaml) returns 200.

## Screenshot

Not applicable. Two URL string changes; the rendered guide is identical except the sample link now resolves.
