### PR TITLE
fix(proxy-actions): clarify x-amp-project-id header requires UUID

### DIFF
--- a/src/proxy-actions.mdx
+++ b/src/proxy-actions.mdx
@@ -23,7 +23,7 @@ Please refer to the [Provider Guides](/provider-guides) for the base URL of each
 Keep the request body and HTTP verb the same, and add these additional headers so Ampersand knows how to deliver the API request:
 
 * `x-amp-proxy-version`: this should always be 1
-* `x-amp-project-id`: your Ampersand project UUID, not the project name. You can find it on your project's [General Settings page](https://dashboard.withampersand.com/projects/_/settings). Unlike Platform API paths that accept either project name or UUID, this header requires the UUID.
+* `x-amp-project-id`: your Ampersand project ID, not the project name. You can find it on your project's [General Settings page](https://dashboard.withampersand.com/projects/_/settings).
 * `x-api-key`: your Ampersand API key, if you don't have one yet, create one in the Ampersand Dashboard's [API Keys page](https://dashboard.withampersand.com/projects/_/api-keys).
 
 In order for Ampersand to know which SaaS instance to make the API call against, you'll need to provide either:

--- a/src/proxy-actions.mdx
+++ b/src/proxy-actions.mdx
@@ -23,7 +23,7 @@ Please refer to the [Provider Guides](/provider-guides) for the base URL of each
 Keep the request body and HTTP verb the same, and add these additional headers so Ampersand knows how to deliver the API request:
 
 * `x-amp-proxy-version`: this should always be 1
-* `x-amp-project-id`: your Ampersand project ID. You can find it on your project's [General Settings page](https://dashboard.withampersand.com/projects/_/settings)
+* `x-amp-project-id`: your Ampersand project UUID, not the project name. You can find it on your project's [General Settings page](https://dashboard.withampersand.com/projects/_/settings). Unlike Platform API paths that accept either project name or UUID, this header requires the UUID.
 * `x-api-key`: your Ampersand API key, if you don't have one yet, create one in the Ampersand Dashboard's [API Keys page](https://dashboard.withampersand.com/projects/_/api-keys).
 
 In order for Ampersand to know which SaaS instance to make the API call against, you'll need to provide either:
@@ -40,7 +40,7 @@ Here is an example API call:
 ```bash
 curl --location --request PUT 'https://proxy.withampersand.com/services/data/v56.0/sobjects/Account' \
 --header 'Content-Type: application/json' \ # Other content types are supported
---header 'x-amp-project-id: my-ampersand-project-id' \
+--header 'x-amp-project-id: <PROJECT_UUID>' \
 --header 'x-api-key: my-api-key' \
 --header 'x-amp-proxy-version: 1' \
 --header 'x-amp-integration-name: my-salesforce-integration' \


### PR DESCRIPTION
## Description

`proxy-actions.mdx` documents `x-amp-project-id` as "your Ampersand project ID" without distinguishing project **name** from project **UUID**. The proxy server actually requires the UUID; the project name (which works on Platform API paths like `/v1/projects/{projectIdOrName}/...`) returns HTTP 403 at the proxy.

This PR is a 2-line wording fix and an example-placeholder update:

- Change the description to make clear the header must be the UUID, with a one-sentence note about the inconsistency with Platform API paths.
- Change the example placeholder from `my-ampersand-project-id` to `<PROJECT_UUID>` so the example doesn't suggest a plain identifier is acceptable.

**Verified**: while exercising an Anthropic proxy integration, `x-amp-project-id: drift-check` (project name) returned 403 `"Ampersand user or API key is not authorized to access this resource"`; the identical request with `x-amp-project-id: <UUID>` returned 200 with the expected response body.

## Screenshot

Not applicable. Pure wording clarification in `proxy-actions.mdx`; no provider-guide content or behavior changes.
