### PR TITLE
[CON-3072] feat(gusto): extend provider guide

### DIFF
--- a/src/provider-guides/gusto.mdx
+++ b/src/provider-guides/gusto.mdx
@@ -61,7 +61,7 @@ The Gusto connector supports writing to the following objects:
 
 ### Example integration
 
-For an example manifest file of a Gusto integration, visit our [samples repo on Github](https://github.com/amp-labs/samples/blob/main/gusto/amp.yaml).
+For an example manifest file of a Gusto integration, visit our [samples repo on GitHub](https://github.com/amp-labs/samples/blob/main/gusto/amp.yaml).
 
 ## Before you get started
 

--- a/src/provider-guides/gusto.mdx
+++ b/src/provider-guides/gusto.mdx
@@ -8,23 +8,60 @@ title: Gusto
 
 This connector supports:
 
+- [Read Actions](/read-actions), including full historic backfill. Please note that incremental read is not supported, a full read of the Gusto instance will be done for each scheduled read.
+- [Write Actions](/write-actions).
 - [Proxy Actions](/proxy-actions), using the base URL `https://api.gusto.com`.
+
+### Supported objects
+
+The Gusto connector supports reading from the following objects:
+
+- [admins](https://docs.gusto.com/app-integrations/reference)
+- [companies](https://docs.gusto.com/app-integrations/reference)
+- [company_benefits](https://docs.gusto.com/app-integrations/reference)
+- [contractor_payments](https://docs.gusto.com/app-integrations/reference)
+- [contractors](https://docs.gusto.com/app-integrations/reference)
+- [custom_fields](https://docs.gusto.com/app-integrations/reference)
+- [departments](https://docs.gusto.com/app-integrations/reference)
+- [earning_types](https://docs.gusto.com/app-integrations/reference)
+- [employee_benefits](https://docs.gusto.com/app-integrations/reference)
+- [employees](https://docs.gusto.com/app-integrations/reference)
+- [garnishments](https://docs.gusto.com/app-integrations/reference)
+- [home_addresses](https://docs.gusto.com/app-integrations/reference)
+- [jobs](https://docs.gusto.com/app-integrations/reference)
+- [locations](https://docs.gusto.com/app-integrations/reference)
+- [pay_periods](https://docs.gusto.com/app-integrations/reference)
+- [pay_schedules](https://docs.gusto.com/app-integrations/reference)
+- [payrolls](https://docs.gusto.com/app-integrations/reference)
+- [time_off_activities](https://docs.gusto.com/app-integrations/reference)
+- [work_addresses](https://docs.gusto.com/app-integrations/reference)
+
+The Gusto connector supports writing to the following objects:
+
+- [admins](https://docs.gusto.com/app-integrations/reference)
+- [companies](https://docs.gusto.com/app-integrations/reference)
+- [company_benefits](https://docs.gusto.com/app-integrations/reference)
+- [compensations](https://docs.gusto.com/app-integrations/reference)
+- [contractor_payments](https://docs.gusto.com/app-integrations/reference)
+- [contractors](https://docs.gusto.com/app-integrations/reference)
+- [departments](https://docs.gusto.com/app-integrations/reference)
+- [earning_types](https://docs.gusto.com/app-integrations/reference)
+- [employee_benefits](https://docs.gusto.com/app-integrations/reference)
+- [employees](https://docs.gusto.com/app-integrations/reference)
+- [garnishments](https://docs.gusto.com/app-integrations/reference)
+- [home_addresses](https://docs.gusto.com/app-integrations/reference)
+- [jobs](https://docs.gusto.com/app-integrations/reference)
+- [locations](https://docs.gusto.com/app-integrations/reference)
+- [pay_periods](https://docs.gusto.com/app-integrations/reference)
+- [pay_schedules](https://docs.gusto.com/app-integrations/reference)
+- [payrolls](https://docs.gusto.com/app-integrations/reference)
+- [work_addresses](https://docs.gusto.com/app-integrations/reference)
+
 
 
 ### Example integration
 
-To define an integration for Gusto, create a manifest file that looks like this:
-
-```YAML
-# amp.yaml
-specVersion: 1.0.0
-integrations:
-  - name: gusto-integration
-    displayName: My Gusto Integration
-    provider: gusto
-    proxy:
-      enabled: true
-```
+To define an integration for Gusto, create a manifest file that looks like this: https://github.com/amp-labs/samples/blob/main/gusto/amp.yaml
 
 ## Before you get started
 
@@ -75,6 +112,9 @@ To start integrating with Gusto:
 
 - Create a manifest file like the [example above](#example-integration).
 - Deploy it using the [amp CLI](/cli/overview).
+- If you are using Read Actions, create a [destination](/destinations).
 - Embed the [InstallIntegration](/embeddable-ui-components#install-integration) UI component. The UI component will prompt the customer for OAuth authorization.
 - Start using the connector!
+  - If your integration has [Read Actions](/read-actions), you'll start getting webhook messages.
+  - If your integration has [Write Actions](/write-actions), you can start making API calls to our Write API.
   - If your integration has [Proxy Actions](/proxy-actions), you can start making Proxy API calls.

--- a/src/provider-guides/gusto.mdx
+++ b/src/provider-guides/gusto.mdx
@@ -61,7 +61,7 @@ The Gusto connector supports writing to the following objects:
 
 ### Example integration
 
-To define an integration for Gusto, create a manifest file that looks like this: https://github.com/amp-labs/samples/blob/main/gusto/amp.yaml
+For an example manifest file of a Gusto integration, visit our [samples repo on Github](https://github.com/amp-labs/samples/blob/main/gusto/amp.yaml).
 
 ## Before you get started
 


### PR DESCRIPTION
## Description
Extend gusto provider guide to support Deep connector

## Screenshot
<img width="2536" height="8858" alt="localhost_3000_provider-guides_gusto" src="https://github.com/user-attachments/assets/5ea307a7-e98f-4ff3-8b62-954b30d46756" />
