### PR TITLE
docs(paddle): describe sample as read/write/proxy example

### DIFF
--- a/src/provider-guides/paddle.mdx
+++ b/src/provider-guides/paddle.mdx
@@ -48,7 +48,7 @@ The Paddle connector supports writing to the following objects:
 
 ### Example integration
 
-For a minimal Proxy Actions example manifest, visit our [samples repo on GitHub](https://github.com/amp-labs/samples/blob/main/paddle/amp.yaml). This sample is proxy-only; Read and Write Action declarations are intentionally omitted.
+For an example manifest with Read Actions, Write Actions, and Proxy Actions, visit our [samples repo on GitHub](https://github.com/amp-labs/samples/blob/main/paddle/amp.yaml).
 
 
 ## Creating an API key
@@ -60,7 +60,7 @@ For a minimal Proxy Actions example manifest, visit our [samples repo on GitHub]
 This connector uses API Key auth, which means that you do not need to set up a Provider App before getting started. (Provider apps are only required for providers that use OAuth2 Authorization Code grant type.)
 
 To start integrating with Paddle:
-- Create a manifest file using the [proxy-only example](https://github.com/amp-labs/samples/blob/main/paddle/amp.yaml). To add Read or Write Actions, see the [manifest reference](/manifest-reference).
+- Create a manifest file using the [example](https://github.com/amp-labs/samples/blob/main/paddle/amp.yaml). Add or remove objects based on the Paddle data you want to sync or write.
 - Deploy it using the [amp CLI](/cli/overview).
 - If you are using Read Actions, create a [destination](/destinations).
 - Embed the [InstallIntegration](/embeddable-ui-components#install-integration) UI component.

--- a/src/provider-guides/paddle.mdx
+++ b/src/provider-guides/paddle.mdx
@@ -48,7 +48,7 @@ The Paddle connector supports writing to the following objects:
 
 ### Example integration
 
-For an example manifest file of an Paddle integration, visit our [samples repo on Github](https://github.com/amp-labs/samples/blob/main/paddle/amp.yaml).
+For a minimal Proxy Actions example manifest, visit our [samples repo on GitHub](https://github.com/amp-labs/samples/blob/main/paddle/amp.yaml). This sample is proxy-only; Read and Write Action declarations are intentionally omitted.
 
 
 ## Creating an API key
@@ -60,7 +60,7 @@ For an example manifest file of an Paddle integration, visit our [samples repo o
 This connector uses API Key auth, which means that you do not need to set up a Provider App before getting started. (Provider apps are only required for providers that use OAuth2 Authorization Code grant type.)
 
 To start integrating with Paddle:
-- Create a manifest file using the [example](https://github.com/amp-labs/samples/blob/main/paddle/amp.yaml).
+- Create a manifest file using the [proxy-only example](https://github.com/amp-labs/samples/blob/main/paddle/amp.yaml). To add Read or Write Actions, see the [manifest reference](/manifest-reference).
 - Deploy it using the [amp CLI](/cli/overview).
 - If you are using Read Actions, create a [destination](/destinations).
 - Embed the [InstallIntegration](/embeddable-ui-components#install-integration) UI component.


### PR DESCRIPTION
Updates the Paddle provider guide so the sample-link wording matches the paired `samples/paddle/amp.yaml` change.

- The companion samples PR (amp-labs/samples#135) now adds a representative Read/Write/Proxy Paddle manifest, not a proxy-only manifest.
- The sample declares Read Actions for `products`, `prices`, and `transactions`; Write Actions for `products`, `prices`, and `customers`; and Proxy Actions.
- Pairs with amp-labs/samples#135.
- Harness evidence: run `2026-05-30T13-26-55-165Z-paddle` against the exact file in #135. Manifest sha256 `877ece69931c89ac47a8672a2222ecec900a32d6c872d919b70f4e924878f8c8`; modes completed: `proxy-smoke`; findings: 0; live-key detected (`pdl_live_`), writes blocked by harness rule.
- Does not runtime-validate Paddle Read delivery or Write execution; current evidence verifies deploy + connection + installation + proxy + cleanup.