### PR TITLE
[CON-3226] feat(goTo): extended goTo provider guide

### DIFF
--- a/src/provider-guides/goTo.mdx
+++ b/src/provider-guides/goTo.mdx
@@ -1,80 +1,124 @@
 ---
-title: "GoTo"
+title: GoTo
 ---
 
-The GoTo connector supports GoTo products which have APIs with the root URL `api.getgo.com`, these include:
+## What's supported
 
-- GoToWebinar
-- GoToMeeting
-
-## What's Supported
-
-### Supported Actions
+### Supported actions
 
 This connector supports:
 
+- [Read Actions](/read-actions), including full historic backfill and incremental read for `historicalMeetings`, `webinars`, and `sessions`. For all other objects, a full read of the Github instance will be done per scheduled read.
+- [Write Actions](/write-actions).
 - [Proxy Actions](/proxy-actions), using the base URL `https://api.getgo.com`.
 
-## Before You Get Started
+### Supported objects
 
-To integrate GoTo with Ampersand, you need to [Create a GoTo Account](https://developer.goto.com/signup/) and obtain the following credentials from your GoTo App:
+The GoTo connector supports reading from the following objects:
+
+- [historicalMeetings](https://developer.goto.com/GoToMeetingV1/#tag/Meetings/operation/getHistoricalMeetings)
+- [upcomingMeetings](https://developer.goto.com/GoToMeetingV1/#tag/Meetings/operation/getUpcomingMeetings)
+- [webinars](https://developer.goto.com/GoToWebinarV2/#tag/Webinars/operation/getAllAccountWebinars)
+- [webhooks](https://developer.goto.com/GoToWebinarV2/#tag/Webhooks/operation/getWebhooks)
+- [userSubscriptions](https://developer.goto.com/GoToWebinarV2/#tag/Webhooks/operation/getUserSubscriptions)
+- [representatives](https://developer.goto.com/g2a-c#tag/Representatives/paths/~1representatives~1pages/get)
+- [teams](https://developer.goto.com/g2a-c#tag/Teams/paths/~1teams~1pages/get)
+- [portals](https://developer.goto.com/g2a-c#tag/Portals/paths/~1portals~1pages/get)
+- [sessions](https://developer.goto.com/g2a-rs#tag/Sessions/paths/~1G2A~1rest~1v1~1sessions/get)
+- [attributes](https://developer.goto.com/admin#tag/Attributes/operation/Get%20All%20Attributes)
+- [licenses](https://developer.goto.com/admin#tag/Licenses/operation/Get%20Licenses)
+- [rolesets](https://developer.goto.com/admin#tag/Role-Sets/operation/Get%20Role%20Sets)
+- [admin/users](https://developer.goto.com/admin#tag/Users/operation/Get%20Users)
+- [admin/groups](https://developer.goto.com/admin#tag/Groups/operation/Get%20Groups)
+- [users](https://developer.goto.com/Scim#tag/Users/operation/getUsers)
+- [groups](https://developer.goto.com/Scim#tag/Groups/operation/getGroups)
+
+The GoTo connector supports writing to the following objects:
+
+- [webhooks](https://developer.goto.com/GoToWebinarV2#tag/Webhooks/operation/createWebhooks)
+- [userSubscriptions](https://developer.goto.com/GoToWebinarV2#tag/Webhooks/operation/createUserSubscriptions)
+- [representatives](https://developer.goto.com/g2a-c#tag/Representatives/paths/~1representatives/post)
+- [teams](https://developer.goto.com/g2a-c#tag/Teams/paths/~1teams/post)
+- [rolesets](https://developer.goto.com/admin#tag/Role-Sets/operation/Add%20Role%20Set)
+- [admin/users](https://developer.goto.com/Scim)
+- [admin/groups](https://developer.goto.com/Scim)
+- [users](https://developer.goto.com/Scim#tag/Users/operation/createUsers)
+- [groups](https://developer.goto.com/Scim#tag/Groups/operation/createGroup)
+- [meetings](https://developer.goto.com/GoToMeetingV1/#tag/Meetings)
+- [tickets](https://developer.goto.com/LogMeInResolve/#tag/Ticketing)
+
+### Example integration
+
+For an example manifest file of a GoTo integration, visit our [samples repo on GitHub](https://github.com/amp-labs/samples/blob/main/goTo/amp.yaml).
+
+
+## Before you get started
+
+To integrate GoTo with Ampersand, create a GoTo developer account and a GoTo OAuth app. You need these credentials from the app:
 
 - Client ID
 - Client Secret
 
-You will then use this credential to connect your application to Ampersand.
+Ampersand does not require a separate provider app for any other auth flow, because this connector uses OAuth2 Authorization Code.
 
-### Create a GoTo Account
+GoTo also exposes an `accountKey` after authentication. Ampersand fetches it from the authenticated GoTo account and uses it to resolve GoTo paths automatically; you do not enter it manually.
 
-Here's how you can sign up for an GoTo account:
+### Create a GoTo account
 
-1. Go to the [GoTo SignUp page](https://developer.goto.com/signup/).
+Here's how you can sign up for a GoTo account:
+
+1. Go to the [GoTo sign-up page](https://developer.goto.com/signup/).
 2. Fill in the necessary details and register your account.
 
-### Creating an OAuth app in GoTo
+### Creating a GoTo OAuth app
 
-Once your GoTo account is ready, you need to create an OAuth application to connect with Ampersand. Follow the steps below to create the OAuth app:
+Once your GoTo account is ready, create an OAuth application for Ampersand:
 
-1. Log in to Your [GoTo Account](https://identity.goto.com/login).
-
-2. Go to [Developers](https://developer.logmeininc.com/clients).
-
-3. Click on **Create a new client**
-
-4. Go to the **OAuth Apps** tab.
-
-5. Click the **Create App** button.
-
-6. Enter the following details in the **Create OAuth App** form:
-
-   1. **App Name**: The name of the OAuth app.
-   2. **App Description**: Description for the OAuth app.
-   3. **Redirect URL**: Enter the Ampersand redirect URL: `https://api.withampersand.com/callbacks/v1/oauth`
-
+1. Log in to your [GoTo account](https://identity.goto.com/login).
+2. Go to [GoTo developer clients](https://developer.logmeininc.com/clients).
+3. Click **Create a new client**.
+4. Open the **OAuth Apps** tab.
+5. Click **Create App**.
+6. Fill in the app details:
+   1. **App Name**: Choose a name for the OAuth app.
+   2. **App Description**: Add a short description.
+   3. **Redirect URL**: Enter the Ampersand redirect URL: `https://api.withampersand.com/callbacks/v1/oauth`.
 7. Click **Next**.
-
-8. Select the applicable permissions.
-
+8. Select the permissions your app needs.
 9. Click **Save**.
 
-You'll find the **Client ID** and **Client Secret** keys in your Oauth app details. These credentials are required for connecting your app to Ampersand, so be sure to note them carefully.
+You will find the **Client ID** and **Client Secret** in the OAuth app details.
 
 ![GoTo OAuth App Creation](/images/provider-guides/OAuth-goto.gif)
 
-## Add GoTo App Details in Ampersand
+### Add your GoTo app info to Ampersand
 
 1. Log in to your [Ampersand Dashboard](https://dashboard.withampersand.com).
-
-2. Select the project where you want to add the GoTo App.
+2. Select the project where you want to add the GoTo app.
 
    ![Ampersand Project Selection](/images/provider-guides/090c05f-Ampersand.png)
 
 3. Navigate to the **Provider Apps** section.
-
-4. Select **GoTo** from the Provider list.
-
-5. Enter the previously obtained **Client ID** and **Client Secret** in their respective fields.
+4. Select **GoTo** from the provider list.
+5. Enter the **Client ID** and **Client Secret** from your GoTo OAuth app.
 
    ![Ampersand Project Selection](/images/provider-guides/goto-amps.gif)
 
 6. Click **Save Changes**.
+
+## Using the connector
+
+Use the `goTo` module in your manifest. The `goToConnect` module is not implemented yet.
+
+To start integrating with GoTo:
+
+- Create a manifest file like the [example above](#example-integration).
+- Deploy it using the [amp CLI](/cli/overview).
+- If you are using Read Actions, create a [destination](/destinations).
+- Embed the [InstallIntegration](/embeddable-ui-components#install-integration) UI component. The UI component prompts the customer for GoTo OAuth authorization.
+- Start using the connector.
+  - If your integration has [Read Actions](/read-actions), Ampersand delivers webhook messages.
+  - If your integration has [Write Actions](/write-actions), call the Write API.
+  - If your integration has [Proxy Actions](/proxy-actions), call Proxy API requests against `https://api.getgo.com`.
+
+Some GoTo list endpoints require a time window. Ampersand supplies a default window when it samples metadata and when the connector builds requests for those endpoints.

--- a/src/provider-guides/goTo.mdx
+++ b/src/provider-guides/goTo.mdx
@@ -4,6 +4,15 @@ title: GoTo
 
 ## What's supported
 
+### Supported modules
+
+The GoTo connector supports the following module:
+
+| Module | Description | Example |
+| --- | --- | --- |
+| `goTo` _(default)_ | Connects to GoTo products including Admin, Meetings, Webinars, Training, Corporate, Remote Support, and SCIM. | [sample](https://github.com/amp-labs/samples/blob/main/goto/amp.yaml) |
+
+
 ### Supported actions
 
 This connector supports:
@@ -53,7 +62,7 @@ For an example manifest file of a GoTo integration, visit our [samples repo on G
 
 
 ## Before you get started
-
+goto
 To integrate GoTo with Ampersand, you need to [Create a GoTo Account](https://developer.goto.com/signup/) and obtain the following credentials from your GoTo App:
 
 - Client ID
@@ -105,8 +114,6 @@ You'll find the **Client ID** and **Client Secret** keys in your OAuth app detai
 6. Click **Save Changes**.
 
 ## Using the connector
-
-Use the `goTo` module in your manifest.
 
 To start integrating with GoTo:
 

--- a/src/provider-guides/goTo.mdx
+++ b/src/provider-guides/goTo.mdx
@@ -49,7 +49,7 @@ The GoTo connector supports writing to the following objects:
 
 ### Example integration
 
-For an example manifest file of a GoTo integration, visit our [samples repo on GitHub](https://github.com/amp-labs/samples/blob/main/goTo/amp.yaml).
+For an example manifest file of a GoTo integration, visit our [samples repo on GitHub](https://github.com/amp-labs/samples/blob/main/goto/amp.yaml).
 
 
 ## Before you get started

--- a/src/provider-guides/goTo.mdx
+++ b/src/provider-guides/goTo.mdx
@@ -8,7 +8,7 @@ title: GoTo
 
 This connector supports:
 
-- [Read Actions](/read-actions), including full historic backfill and incremental read for `historicalMeetings`, `webinars`, and `sessions`. For all other objects, a full read of the Github instance will be done per scheduled read.
+- [Read Actions](/read-actions), including full historic backfill and incremental read for `historicalMeetings`, `webinars`, and `sessions`. For all other objects, a full read of the GoTo instance will be done per scheduled read.
 - [Write Actions](/write-actions).
 - [Proxy Actions](/proxy-actions), using the base URL `https://api.getgo.com`.
 
@@ -35,8 +35,8 @@ The GoTo connector supports reading from the following objects:
 
 The GoTo connector supports writing to the following objects:
 
-- [admin/groups](https://developer.goto.com/Scim#tag/Groups/operation/createGroup)
-- [admin/users](https://developer.goto.com/Scim#tag/Users/operation/createUsers)
+- [admin/groups](https://developer.goto.com/admin#tag/Groups/operation/Add%20Group)
+- [admin/users](https://developer.goto.com/admin#tag/Users/operation/Add%20Users)
 - [groups](https://developer.goto.com/Scim#tag/Groups/operation/createGroup)
 - [meetings](https://developer.goto.com/GoToMeetingV1/#tag/Meetings)
 - [representatives](https://developer.goto.com/g2a-c#tag/Representatives/paths/~1representatives/post)
@@ -59,8 +59,7 @@ To integrate GoTo with Ampersand, you need to [Create a GoTo Account](https://de
 - Client ID
 - Client Secret
 
-You will then use this credential to connect your application to Ampersand.
-
+You will then use these credentials to connect your application to Ampersand.
 
 ### Create a GoTo account
 
@@ -86,7 +85,7 @@ Once your GoTo account is ready, create an OAuth application for Ampersand:
 8. Select the permissions your app needs.
 9. Click **Save**.
 
-You'll find the **Client ID** and **Client Secret** keys in your Oauth app details. These credentials are required for connecting your app to Ampersand, so be sure to note them carefully.
+You'll find the **Client ID** and **Client Secret** keys in your OAuth app details. These credentials are required for connecting your app to Ampersand, so be sure to note them carefully.
 
 ![GoTo OAuth App Creation](/images/provider-guides/OAuth-goto.gif)
 

--- a/src/provider-guides/goTo.mdx
+++ b/src/provider-guides/goTo.mdx
@@ -12,6 +12,7 @@ The GoTo connector supports the following module:
 | --- | --- | --- |
 | `goTo` _(default)_ | Connects to GoTo products including Admin, Meetings, Webinars, Training, Corporate, Remote Support, and SCIM. | [sample](https://github.com/amp-labs/samples/blob/main/goto/amp.yaml) |
 
+Since `goTo` is the default module, you don't need to set the `module` field in your manifest — it's applied automatically.
 
 ### Supported actions
 

--- a/src/provider-guides/goTo.mdx
+++ b/src/provider-guides/goTo.mdx
@@ -16,36 +16,36 @@ This connector supports:
 
 The GoTo connector supports reading from the following objects:
 
-- [historicalMeetings](https://developer.goto.com/GoToMeetingV1/#tag/Meetings/operation/getHistoricalMeetings)
-- [upcomingMeetings](https://developer.goto.com/GoToMeetingV1/#tag/Meetings/operation/getUpcomingMeetings)
-- [webinars](https://developer.goto.com/GoToWebinarV2/#tag/Webinars/operation/getAllAccountWebinars)
-- [webhooks](https://developer.goto.com/GoToWebinarV2/#tag/Webhooks/operation/getWebhooks)
-- [userSubscriptions](https://developer.goto.com/GoToWebinarV2/#tag/Webhooks/operation/getUserSubscriptions)
-- [representatives](https://developer.goto.com/g2a-c#tag/Representatives/paths/~1representatives~1pages/get)
-- [teams](https://developer.goto.com/g2a-c#tag/Teams/paths/~1teams~1pages/get)
-- [portals](https://developer.goto.com/g2a-c#tag/Portals/paths/~1portals~1pages/get)
-- [sessions](https://developer.goto.com/g2a-rs#tag/Sessions/paths/~1G2A~1rest~1v1~1sessions/get)
-- [attributes](https://developer.goto.com/admin#tag/Attributes/operation/Get%20All%20Attributes)
-- [licenses](https://developer.goto.com/admin#tag/Licenses/operation/Get%20Licenses)
-- [rolesets](https://developer.goto.com/admin#tag/Role-Sets/operation/Get%20Role%20Sets)
+- [admin/groups](https://developer.goto.com/admin#tag/Groups/operation/Get%20Groups)  
 - [admin/users](https://developer.goto.com/admin#tag/Users/operation/Get%20Users)
-- [admin/groups](https://developer.goto.com/admin#tag/Groups/operation/Get%20Groups)
+- [attributes](https://developer.goto.com/admin#tag/Attributes/operation/Get%20All%20Attributes) 
+- [groups](https://developer.goto.com/Scim#tag/Groups/operation/getGroups) 
+- [historicalMeetings](https://developer.goto.com/GoToMeetingV1/#tag/Meetings/operation/getHistoricalMeetings) 
+- [licenses](https://developer.goto.com/admin#tag/Licenses/operation/Get%20Licenses) 
+- [portals](https://developer.goto.com/g2a-c#tag/Portals/paths/~1portals~1pages/get) 
+- [representatives](https://developer.goto.com/g2a-c#tag/Representatives/paths/~1representatives~1pages/get) 
+- [rolesets](https://developer.goto.com/admin#tag/Role-Sets/operation/Get%20Role%20Sets) 
+- [sessions](https://developer.goto.com/g2a-rs#tag/Sessions/paths/~1G2A~1rest~1v1~1sessions/get) 
+- [teams](https://developer.goto.com/g2a-c#tag/Teams/paths/~1teams~1pages/get) 
+- [upcomingMeetings](https://developer.goto.com/GoToMeetingV1/#tag/Meetings/operation/getUpcomingMeetings)
+- [userSubscriptions](https://developer.goto.com/GoToWebinarV2/#tag/Webhooks/operation/getUserSubscriptions)
 - [users](https://developer.goto.com/Scim#tag/Users/operation/getUsers)
-- [groups](https://developer.goto.com/Scim#tag/Groups/operation/getGroups)
+- [webhooks](https://developer.goto.com/GoToWebinarV2/#tag/Webhooks/operation/getWebhooks)
+- [webinars](https://developer.goto.com/GoToWebinarV2/#tag/Webinars/operation/getAllAccountWebinars)
 
 The GoTo connector supports writing to the following objects:
 
-- [webhooks](https://developer.goto.com/GoToWebinarV2#tag/Webhooks/operation/createWebhooks)
-- [userSubscriptions](https://developer.goto.com/GoToWebinarV2#tag/Webhooks/operation/createUserSubscriptions)
-- [representatives](https://developer.goto.com/g2a-c#tag/Representatives/paths/~1representatives/post)
-- [teams](https://developer.goto.com/g2a-c#tag/Teams/paths/~1teams/post)
-- [rolesets](https://developer.goto.com/admin#tag/Role-Sets/operation/Add%20Role%20Set)
-- [admin/users](https://developer.goto.com/Scim)
-- [admin/groups](https://developer.goto.com/Scim)
-- [users](https://developer.goto.com/Scim#tag/Users/operation/createUsers)
+- [admin/groups](https://developer.goto.com/Scim#tag/Groups/operation/createGroup)
+- [admin/users](https://developer.goto.com/Scim#tag/Users/operation/createUsers)
 - [groups](https://developer.goto.com/Scim#tag/Groups/operation/createGroup)
 - [meetings](https://developer.goto.com/GoToMeetingV1/#tag/Meetings)
+- [representatives](https://developer.goto.com/g2a-c#tag/Representatives/paths/~1representatives/post)
+- [rolesets](https://developer.goto.com/admin#tag/Role-Sets/operation/Add%20Role%20Set)
+- [teams](https://developer.goto.com/g2a-c#tag/Teams/paths/~1teams/post)
 - [tickets](https://developer.goto.com/LogMeInResolve/#tag/Ticketing)
+- [users](https://developer.goto.com/Scim#tag/Users/operation/createUsers)
+- [userSubscriptions](https://developer.goto.com/GoToWebinarV2#tag/Webhooks/operation/createUserSubscriptions)
+- [webhooks](https://developer.goto.com/GoToWebinarV2#tag/Webhooks/operation/createWebhooks)
 
 ### Example integration
 
@@ -108,7 +108,7 @@ You will find the **Client ID** and **Client Secret** in the OAuth app details.
 
 ## Using the connector
 
-Use the `goTo` module in your manifest. The `goToConnect` module is not implemented yet.
+Use the `goTo` module in your manifest.
 
 To start integrating with GoTo:
 
@@ -121,4 +121,3 @@ To start integrating with GoTo:
   - If your integration has [Write Actions](/write-actions), call the Write API.
   - If your integration has [Proxy Actions](/proxy-actions), call Proxy API requests against `https://api.getgo.com`.
 
-Some GoTo list endpoints require a time window. Ampersand supplies a default window when it samples metadata and when the connector builds requests for those endpoints.

--- a/src/provider-guides/goTo.mdx
+++ b/src/provider-guides/goTo.mdx
@@ -54,14 +54,13 @@ For an example manifest file of a GoTo integration, visit our [samples repo on G
 
 ## Before you get started
 
-To integrate GoTo with Ampersand, create a GoTo developer account and a GoTo OAuth app. You need these credentials from the app:
+To integrate GoTo with Ampersand, you need to [Create a GoTo Account](https://developer.goto.com/signup/) and obtain the following credentials from your GoTo App:
 
 - Client ID
 - Client Secret
 
-Ampersand does not require a separate provider app for any other auth flow, because this connector uses OAuth2 Authorization Code.
+You will then use this credential to connect your application to Ampersand.
 
-GoTo also exposes an `accountKey` after authentication. Ampersand fetches it from the authenticated GoTo account and uses it to resolve GoTo paths automatically; you do not enter it manually.
 
 ### Create a GoTo account
 
@@ -87,7 +86,7 @@ Once your GoTo account is ready, create an OAuth application for Ampersand:
 8. Select the permissions your app needs.
 9. Click **Save**.
 
-You will find the **Client ID** and **Client Secret** in the OAuth app details.
+You'll find the **Client ID** and **Client Secret** keys in your Oauth app details. These credentials are required for connecting your app to Ampersand, so be sure to note them carefully.
 
 ![GoTo OAuth App Creation](/images/provider-guides/OAuth-goto.gif)
 

--- a/src/provider-guides/goTo.mdx
+++ b/src/provider-guides/goTo.mdx
@@ -4,16 +4,6 @@ title: GoTo
 
 ## What's supported
 
-### Supported modules
-
-The GoTo connector supports the following module:
-
-| Module | Description | Example |
-| --- | --- | --- |
-| `goTo` _(default)_ | Connects to GoTo products including Admin, Meetings, Webinars, Training, Corporate, Remote Support, and SCIM. | [sample](https://github.com/amp-labs/samples/blob/main/goto/amp.yaml) |
-
-Since `goTo` is the default module, you don't need to set the `module` field in your manifest — it's applied automatically.
-
 ### Supported actions
 
 This connector supports:


### PR DESCRIPTION
## Description
This PR extends goTo provider guide for deep connectors

## Screenshot
<img width="2508" height="11084" alt="localhost_3000_provider-guides_goTo (1)" src="https://github.com/user-attachments/assets/52d4ffe1-9446-4c27-8328-f652a67745c8" />



