### PR TITLE
[Docs] Add contextual menu with copy/view for LLMs

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -8,6 +8,12 @@
     "dark": "#6122E7"
   },
   "favicon": "logos/favicon.svg",
+  "contextual": {
+    "options": [
+      "copy",
+      "view"
+    ]
+  },
   "navigation": {
     "tabs": [
       {

--- a/src/generate-docs.ts
+++ b/src/generate-docs.ts
@@ -25,6 +25,9 @@ export interface DocsConfig {
     dark?: string;
   };
   favicon?: string;
+  contextual?: {
+    options: Array<string>;
+  };
   navigation: {
     tabs: Array<{
       tab: string;
@@ -109,6 +112,9 @@ export function generateDocsConfig(mintConfig: any): DocsConfig {
     name: mintConfig.name,
     colors: mintConfig.colors,
     favicon: mintConfig.favicon,
+    contextual: {
+      options: ['copy', 'view']
+    },
     navigation: {
       tabs: [
         {


### PR DESCRIPTION
## What

Enables Mintlify's [contextual menu](https://www.mintlify.com/docs/ai/contextual-menu) so every docs page gets one-click AI-friendly actions in the page header:

- **Copy page** (`copy`) — copies the page as Markdown for pasting as context into ChatGPT/Claude/etc.
- **View as Markdown** (`view`) — opens the raw Markdown version of the page.

## How

- Added a `contextual` field to the `DocsConfig` type and emitted it in `generateDocsConfig` in `src/generate-docs.ts` (the source of truth).
- Regenerated `src/docs.json` via `make gen`.

## Testing 
<img width="1638" height="894" alt="image" src="https://github.com/user-attachments/assets/40770b03-c16a-4eda-999a-32ff4173df0b" />
