### PR TITLE
chore: removing confusing sentence from stripe guide

### DIFF
--- a/src/provider-guides/stripe.mdx
+++ b/src/provider-guides/stripe.mdx
@@ -6,7 +6,7 @@ title: Stripe
 ### Supported actions
 
 The Stripe connector supports:
-- [Read Actions](/read-actions), including full historic backfill. A full read of the Stripe instance will be done for each scheduled read. Please note that incremental read is supported for several object, see below.
+- [Read Actions](/read-actions), including full historic backfill.
 - [Write Actions](/write-actions).
 - [Proxy Actions](/proxy-actions), using the base URL `https://api.stripe.com`.
 


### PR DESCRIPTION
## Description

## Screenshot

Please include a screenshot of the documentation running locally with `cd src && mint dev`. 
