### PR TITLE
docs: fix broken Gusto sample link

### DIFF
--- a/src/provider-guides/gusto.mdx
+++ b/src/provider-guides/gusto.mdx
@@ -57,11 +57,20 @@ The Gusto connector supports writing to the following objects:
 - [payrolls](https://docs.gusto.com/app-integrations/reference)
 - [work_addresses](https://docs.gusto.com/app-integrations/reference)
 
-
-
 ### Example integration
 
-For an example manifest file of a Gusto integration, visit our [samples repo on GitHub](https://github.com/amp-labs/samples/blob/main/gusto/amp.yaml).
+To define a minimal Gusto integration with Proxy Actions, create a manifest file that looks like this:
+
+```YAML
+# amp.yaml
+specVersion: 1.0.0
+integrations:
+  - name: gusto-integration
+    displayName: My Gusto Integration
+    provider: gusto
+    proxy:
+      enabled: true
+```
 
 ## Before you get started
 
@@ -110,7 +119,7 @@ For more details, see the [Gusto Authentication documentation](https://docs.gust
 
 To start integrating with Gusto:
 
-- Create a manifest file like the [example above](#example-integration).
+- Create a manifest file like the example above, then add Read or Write objects if your integration uses those actions.
 - Deploy it using the [amp CLI](/cli/overview).
 - If you are using Read Actions, create a [destination](/destinations).
 - Embed the [InstallIntegration](/embeddable-ui-components#install-integration) UI component. The UI component will prompt the customer for OAuth authorization.


### PR DESCRIPTION
## Summary

Fixes the Gusto provider guide's broken sample link by replacing the missing `samples/gusto/amp.yaml` reference with an inline minimal `amp.yaml` example.

## Why

The drift checker flagged the Gusto guide because it linked to `amp-labs/samples/gusto/amp.yaml`, which does not currently exist.

This keeps the guide's Read, Write, and Proxy support claims unchanged. The issue being fixed here is the broken example link.

## Verification

```sh
pnpm run drift-check -- --mode provider --provider gusto --out /tmp/amp-drift-gusto-after-write-verify
```

Result: `0 findings`
