### PR TITLE
[ENG-3967] docs: `subscribe.create.error` notification

### DIFF
--- a/src/notifications/notification-payloads.mdx
+++ b/src/notifications/notification-payloads.mdx
@@ -373,6 +373,46 @@ Note: `error` describes what went wrong during the triggered read.
 Note: For partial failures, `success` is `false` with both `successfulRecordIds` and `errors` populated.
 </Accordion>
 
+<Accordion title="subscribe.create.error">
+**Webhook destination payload:**
+```json
+{
+  "notificationType": "subscribe.create.error",
+  "data": {
+    "projectId": "8f4a2b1c-3d5e-4f6a-9b0c-1d2e3f4a5b6c",
+    "provider": "salesforce",
+    "integrationId": "7c9e6679-7425-40de-944b-e07fc1f90ae7",
+    "integrationName": "Salesforce Integration",
+    "installationId": "a3bb189e-8bf9-3888-9912-ace4e6543002",
+    "connectionId": "c4e7f2a1-8b3d-4f6e-9a2c-5d1e3f4b6a7c",
+    "groupRef": "customer-group-ref",
+    "groupName": "Customer Name",
+    "consumerRef": "user-123",
+    "consumerName": "John Doe",
+    "error": "provider returned 403: insufficient access to EventChannelMember"
+  }
+}
+```
+
+**Kinesis destination payload:**
+```json
+{
+  "projectId": "8f4a2b1c-3d5e-4f6a-9b0c-1d2e3f4a5b6c",
+  "provider": "salesforce",
+  "integrationId": "7c9e6679-7425-40de-944b-e07fc1f90ae7",
+  "integrationName": "Salesforce Integration",
+  "installationId": "a3bb189e-8bf9-3888-9912-ace4e6543002",
+  "connectionId": "c4e7f2a1-8b3d-4f6e-9a2c-5d1e3f4b6a7c",
+  "groupRef": "customer-group-ref",
+  "groupName": "Customer Name",
+  "consumerRef": "user-123",
+  "consumerName": "John Doe",
+  "error": "provider returned 403: insufficient access to EventChannelMember"
+}
+```
+
+</Accordion>
+
 <Accordion title="Connection events (created, refreshed, deleted)">
 `connection.created`, `connection.refreshed`, and `connection.deleted` share the same payload shape. `notificationType` reflects the specific event.
 

--- a/src/notifications/overview.mdx
+++ b/src/notifications/overview.mdx
@@ -30,6 +30,9 @@ Ampersand supports the following notification event types:
 **Write operations**
 - **`write.async.done`**: Fires when an asynchronous write operation completes, indicating success or failure and which records were written or had errors
 
+**Subscribe**
+- **`subscribe.create.error`**: Fires when Ampersand fails to set up a subscribe action for an installation
+
 **Connection**
 - **`connection.created`**: Fires when a new OAuth connection is established with a SaaS provider
 - **`connection.refreshed`**: Fires when a connection's OAuth access token is refreshed


### PR DESCRIPTION
## Description

Adds docs for new notification type with schema:  


```
{
  "notificationType": "subscribe.create.error",
  "data": {
    "projectId": "8f3a2b1c-…",
    "provider": "salesforce",
    "integrationId": "a1b2c3d4-…",
    "integrationName": "salesforce-crm-sync",
    "installationId": "f0e9d8c7-…",
    "connectionId": "c9b8a7d6-…",
    "groupRef": "acme-corp",
    "groupName": "Acme Corp",
    "consumerRef": "user-4837",
    "consumerName": "jane@acme.com",
    "error": "provider returned 403: insufficient access to EventChannelMember"
  }
}
```

## Screenshot

Please include a screenshot of the documentation running locally with `cd src && mint dev`.

<img width="1504" height="771" alt="Screenshot 2026-06-15 at 10 24 10 AM" src="https://github.com/user-attachments/assets/a6db059f-b898-4dab-be22-ed6e2701e637" />
<img width="1504" height="771" alt="Screenshot 2026-06-15 at 10 23 23 AM" src="https://github.com/user-attachments/assets/1f53890e-c818-4969-aa81-6a0852633a7b" />
<img width="1504" height="771" alt="Screenshot 2026-06-15 at 10 23 31 AM" src="https://github.com/user-attachments/assets/88730701-fb95-4120-b6bc-f458ef22178e" />
