### PR TITLE
[CON-3033] feat(connectwise): Write with Patch

### DIFF
--- a/src/provider-guides/connectWise.mdx
+++ b/src/provider-guides/connectWise.mdx
@@ -232,8 +232,24 @@ export function renderCellValue(value) {
   </table>
 </div>
 
-
 See the official [OpenAPI](https://developer.connectwise.com/Products/ConnectWise_PSA/REST) file for the complete list. (Requires ConnectWise Developer Network account)
+
+Connector supports write operations using a [JSON Patch document](https://datatracker.ietf.org/doc/html/rfc6902#section-3) passed in `record.patch`.
+When performing an update, `record.id` must also be provided so the connector can resolve which record to patch.
+
+Write payload example for the `contacts` object:
+```json
+{
+  "groupRef": "{{connectWiseGroupID}}",
+  "type": "update",
+  "record": {
+    "id": "58016",
+    "patch": [
+      {"op": "replace", "path": "/firstName", "value": "John"}
+    ]
+  }
+}
+```
 
 ### Example integration
 


### PR DESCRIPTION
## Description

This change exposes the API behavior for partial updates. When users want to modify only part of an object instead of replacing the full resource, they can provide a JSON Patch document. This allows PATCH-style updates to be expressed explicitly while keeping PUT-style updates available for full object replacement.

Traditionally the API endpoint would accept payload as array [{op path value}, {...}, {...}].

## Screenshot

<img width="755" height="526" alt="image" src="https://github.com/user-attachments/assets/abe8c24a-e531-483f-beb2-9f1a9a4eddca" />

