### PR TITLE
[CON-3246] feat(connectwise): Subsribe

### DIFF
--- a/src/provider-guides/connectWise.mdx
+++ b/src/provider-guides/connectWise.mdx
@@ -7,6 +7,7 @@ title: ConnectWise
 
 This connector supports:
 - [Read Actions](/read-actions), including full historic backfill and incremental read. Please note that incremental read is unreliable due to ConnectWise API limitations. You may get more data than what is within the time range.
+- [Subscribe Actions](/subscribe-actions).
 - [Write Actions](/write-actions).
 - [Proxy Actions](/proxy-actions), using the base URL `https://{{.region}}.myconnectwise.net`.
 

--- a/src/provider-guides/connectWise.mdx
+++ b/src/provider-guides/connectWise.mdx
@@ -15,22 +15,25 @@ The ConnectWise connector supports reading from all standard objects and writing
 
 export const rows = [
   {
-    label: "activities", read: true, write: true, subscribe: false,
+    label: "activities", read: true, write: true, subscribe: true,
     href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/Activities"
   }, {
-    label: "agreements", read: true, write: true, subscribe: false,
-    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/Agreements",
+    label: "activities", read: true, write: true, subscribe: true,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/Activities"
   }, {
     label: "attachments", read: true, write: false, subscribe: false,
     href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/WorkflowAttachments",
   }, {
-    label: "companies", read: true, write: true, subscribe: false,
+    label: "companies", read: true, write: true, subscribe: true,
     href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/Companies",
   }, {
-    label: "configurations", read: true, write: true, subscribe: false,
+    label: "catalog", read: true, write: true, subscribe: true,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/CatalogsItem",
+  }, {
+    label: "configurations", read: true, write: true, subscribe: true,
     href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/Configurations",
   }, {
-    label: "contacts", read: true, write: true, subscribe: false,
+    label: "contacts", read: true, write: true, subscribe: true,
     href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/Contacts",
   }, {
     label: "countries", read: true, write: true, subscribe: false,
@@ -51,7 +54,7 @@ export const rows = [
     label: "entityTypes", read: true, write: false, subscribe: false,
     href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/EntityTypes",
   }, {
-    label: "expense/entries", read: true, write: true, subscribe: false,
+    label: "expense/entries", read: true, write: true, subscribe: true,
     href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/ExpenseEntries",
   }, {
     label: "finance/agreements/types", read: true, write: true, subscribe: false,
@@ -69,7 +72,7 @@ export const rows = [
     label: "groups", read: true, write: true, subscribe: false,
     href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/Groups",
   }, {
-    label: "invoices", read: true, write: true, subscribe: false,
+    label: "invoices", read: true, write: true, subscribe: true,
     href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/Invoices",
   }, {
     label: "knowledgeBaseArticles", read: true, write: true, subscribe: false,
@@ -87,7 +90,7 @@ export const rows = [
     label: "noteTypes", read: true, write: true, subscribe: false,
     href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/CompanyNoteTypes",
   }, {
-    label: "sales/opportunities", read: true, write: true, subscribe: false,
+    label: "sales/opportunities", read: true, write: true, subscribe: true,
     href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/Opportunities",
   }, {
     label: "orders", read: true, write: true, subscribe: false,
@@ -102,10 +105,13 @@ export const rows = [
     label: "project/projectTemplates", read: true, write: true, subscribe: false,
     href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/ProjectTemplates",
   }, {
-    label: "projects", read: true, write: true, subscribe: false,
+    label: "project/tickets", read: true, write: true, subscribe: true,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/ProjectTickets",
+  }, {
+    label: "projects", read: true, write: true, subscribe: true,
     href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/Projects",
   }, {
-    label: "purchaseorders", read: true, write: true, subscribe: false,
+    label: "purchaseorders", read: true, write: true, subscribe: true,
     href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/PurchaseOrders",
   }, {
     label: "quotas", read: true, write: true, subscribe: false,
@@ -123,7 +129,7 @@ export const rows = [
     label: "rmaStatuses", read: true, write: true, subscribe: false,
     href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/RmaStatuses",
   }, {
-    label: "schedule/entries", read: true, write: true, subscribe: false,
+    label: "schedule/entries", read: true, write: true, subscribe: true,
     href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/ScheduleEntries",
   }, {
     label: "securityRoles", read: true, write: true, subscribe: false,
@@ -135,7 +141,8 @@ export const rows = [
     label: "service/slas/info", read: true, write: false, subscribe: false,
     href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/SLAInfos",
   }, {
-    label: "service/tickets", read: true, write: true, subscribe: false,
+    label: "service/tickets", read: true, write: true,
+    subscribe: <a href={"#row/project/tickets"}>Use project/tickets</a>,
     href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/Tickets",
   }, {
     label: "sources", read: true, write: true, subscribe: false,
@@ -153,7 +160,7 @@ export const rows = [
     label: "system/locations", read: true, write: true, subscribe: false,
     href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/Locations",
   }, {
-    label: "system/members", read: true, write: true, subscribe: false,
+    label: "system/members", read: true, write: true, subscribe: true,
     href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/Members",
   }, {
     label: "system/securityroles/info", read: true, write: false, subscribe: false,
@@ -165,7 +172,7 @@ export const rows = [
     label: "ticketLinks", read: true, write: true, subscribe: false,
     href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/ServiceTicketLinks",
   }, {
-    label: "time/entries", read: true, write: true, subscribe: false,
+    label: "time/entries", read: true, write: true, subscribe: true,
     href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/TimeEntries",
   }, {
     label: "warehouses", read: true, write: true, subscribe: false,
@@ -178,6 +185,18 @@ export const rows = [
 
 export const Check = () => <span>✅</span>
 export const Cross = () => <span>🚫</span>
+
+export function renderCellValue(value) {
+  if (typeof value === "boolean") {
+    return value ? <Check/> : <Cross/>;
+  }
+
+  if (typeof value === "string" && value.startsWith("<")) {
+    return <span dangerouslySetInnerHTML={{__html: value}}/>;
+  }
+
+  return value;
+}
 
 <div style={{width: '100%', overflowX: 'auto', display: 'block'}}>
   <table style={{
@@ -200,13 +219,13 @@ export const Cross = () => <span>🚫</span>
     {[...rows]
       .sort((a, b) => a.label.localeCompare(b.label))
       .map((row) => (
-        <tr key={row.label}>
+        <tr id={"row/" + row.label} key={row.label}>
           <td style={{textAlign: "left"}}>
             <a href={row.href}>{row.label}</a>
           </td>
-          <td>{row.read ? <Check/> : <Cross/>}</td>
-          <td>{row.write ? <Check/> : <Cross/>}</td>
-          <td>{row.subscribe ? <Check/> : <Cross/>}</td>
+          <td>{renderCellValue(row.read)}</td>
+          <td>{renderCellValue(row.write)}</td>
+          <td>{renderCellValue(row.subscribe)}</td>
         </tr>
       ))}
     </tbody>

--- a/src/provider-guides/connectWise.mdx
+++ b/src/provider-guides/connectWise.mdx
@@ -13,74 +13,204 @@ This connector supports:
 
 The ConnectWise connector supports reading from all standard objects and writing to most standard objects, including the following:
 
+export const rows = [
+  {
+    label: "activities", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/Activities"
+  }, {
+    label: "agreements", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/Agreements",
+  }, {
+    label: "attachments", read: true, write: false, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/WorkflowAttachments",
+  }, {
+    label: "companies", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/Companies",
+  }, {
+    label: "configurations", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/Configurations",
+  }, {
+    label: "contacts", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/Contacts",
+  }, {
+    label: "countries", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/Countries",
+  }, {
+    label: "currencies", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/Currencies",
+  }, {
+    label: "customFieldInfos", read: true, write: false, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/CustomFieldInfos",
+  }, {
+    label: "customReports", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/CustomReports",
+  }, {
+    label: "emailTemplates", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/ServiceEmailTemplates",
+  }, {
+    label: "entityTypes", read: true, write: false, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/EntityTypes",
+  }, {
+    label: "expense/entries", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/ExpenseEntries",
+  }, {
+    label: "finance/agreements/types", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/AgreementTypes",
+  }, {
+    label: "finance/billingCycles/info", read: true, write: false, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/BillingCycleInfos",
+  }, {
+    label: "finance/billingTerms/info", read: true, write: false, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/BillingTermInfos",
+  }, {
+    label: "glAccounts", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/GLAccounts",
+  }, {
+    label: "groups", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/Groups",
+  }, {
+    label: "invoices", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/Invoices",
+  }, {
+    label: "knowledgeBaseArticles", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/KnowledgeBaseArticles",
+  }, {
+    label: "knowledgeBaseCategories", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/KnowledgeBaseCategories",
+  }, {
+    label: "kpis", read: true, write: false, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/KPIs",
+  }, {
+    label: "management", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/Managements",
+  }, {
+    label: "noteTypes", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/CompanyNoteTypes",
+  }, {
+    label: "sales/opportunities", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/Opportunities",
+  }, {
+    label: "orders", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/Orders",
+  }, {
+    label: "priorities", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/Priorities",
+  }, {
+    label: "products", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/ProductsItem",
+  }, {
+    label: "project/projectTemplates", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/ProjectTemplates",
+  }, {
+    label: "projects", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/Projects",
+  }, {
+    label: "purchaseorders", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/PurchaseOrders",
+  }, {
+    label: "quotas", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/SalesQuotas",
+  }, {
+    label: "ratings", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/OpportunityRatings",
+  }, {
+    label: "reports", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/ExpenseReports",
+  }, {
+    label: "rmaActions", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/RMAActions",
+  }, {
+    label: "rmaStatuses", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/RmaStatuses",
+  }, {
+    label: "schedule/entries", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/ScheduleEntries",
+  }, {
+    label: "securityRoles", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/ProjectSecurityRoles",
+  }, {
+    label: "service/boards", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/Boards",
+  }, {
+    label: "service/slas/info", read: true, write: false, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/SLAInfos",
+  }, {
+    label: "service/tickets", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/Tickets",
+  }, {
+    label: "sources", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/Sources",
+  }, {
+    label: "states", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/States",
+  }, {
+    label: "system/departments", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/Departments",
+  }, {
+    label: "system/documents", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/Documents",
+  }, {
+    label: "system/locations", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/Locations",
+  }, {
+    label: "system/members", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/Members",
+  }, {
+    label: "system/securityroles/info", read: true, write: false, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/SecurityRoleInfos",
+  }, {
+    label: "system/workflows/events/actions", read: true, write: false, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/WorkflowActions",
+  }, {
+    label: "ticketLinks", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/ServiceTicketLinks",
+  }, {
+    label: "time/entries", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/TimeEntries",
+  }, {
+    label: "warehouses", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/Warehouses",
+  }, {
+    label: "workflows", read: true, write: true, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/Workflows",
+  },
+]
+
 export const Check = () => <span>✅</span>
 export const Cross = () => <span>🚫</span>
 
-<div style={{ width: '100%', overflowX: 'auto', display: 'block' }}>
-<table style={{ width: '100%', minWidth: '100%', tableLayout: 'fixed', textAlign: 'center', borderCollapse: 'collapse', display: 'table' }}>
-  <thead style={{ display: 'table-header-group', width: '100%' }}>
-    <tr style={{ display: 'table-row', width: '100%' }}>
-      <th style={{ textAlign: 'left', width: '40%' }}>Object</th>
-      <th style={{ width: '30%' }}>Read</th>
-      <th style={{ width: '30%' }}>Write</th>
+<div style={{width: '100%', overflowX: 'auto', display: 'block'}}>
+  <table style={{
+    width: '100%',
+    minWidth: '100%',
+    tableLayout: 'fixed',
+    textAlign: 'center',
+    borderCollapse: 'collapse',
+    display: 'table'
+  }}>
+    <thead style={{display: 'table-header-group', width: '100%'}}>
+    <tr style={{display: 'table-row', width: '100%'}}>
+      <th style={{textAlign: 'left', width: '40%'}}>Object</th>
+      <th style={{width: '20%'}}>Read</th>
+      <th style={{width: '20%'}}>Write</th>
+      <th style={{width: '20%'}}>Subscribe</th>
     </tr>
-  </thead>
-  <tbody style={{ display: 'table-row-group', width: '100%' }}>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>activities</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>agreements</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>attachments</td><td><Check /></td><td><Cross /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>companies</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>configurations</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>contacts</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>countries</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>currencies</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>customFieldInfos</td><td><Check /></td><td><Cross /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>customReports</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>emailTemplates</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>entityTypes</td><td><Check /></td><td><Cross /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>expense/entries</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>finance/agreements/types</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>finance/billingCycles/info</td><td><Check /></td><td><Cross /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>finance/billingTerms/info</td><td><Check /></td><td><Cross /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>glAccounts</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>groups</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>invoices</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>knowledgeBaseArticles</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>knowledgeBaseCategories</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>kpis</td><td><Check /></td><td><Cross /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>management</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>noteTypes</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>sales/opportunities</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>orders</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>priorities</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>products</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>project/projectTemplates</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>projects</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>purchaseorders</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>quotas</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>ratings</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>reports</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>rmaActions</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>rmaStatuses</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>schedule/entries</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>securityRoles</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>service/boards</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>service/slas/info</td><td><Check /></td><td><Cross /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>service/tickets</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>sources</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>states</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>system/departments</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>system/documents</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>system/locations</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>system/members</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>system/securityroles/info</td><td><Check /></td><td><Cross /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>system/workflows/events/actions</td><td><Check /></td><td><Cross /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>ticketLinks</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>time/entries</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>warehouses</td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}>workflows</td><td><Check /></td><td><Check /></td></tr>
-  </tbody>
-</table>
+    </thead>
+    <tbody style={{display: 'table-row-group', width: '100%'}}>
+    {[...rows]
+      .sort((a, b) => a.label.localeCompare(b.label))
+      .map((row) => (
+        <tr key={row.label}>
+          <td style={{textAlign: "left"}}>
+            <a href={row.href}>{row.label}</a>
+          </td>
+          <td>{row.read ? <Check/> : <Cross/>}</td>
+          <td>{row.write ? <Check/> : <Cross/>}</td>
+          <td>{row.subscribe ? <Check/> : <Cross/>}</td>
+        </tr>
+      ))}
+    </tbody>
+  </table>
 </div>
 
 

--- a/src/provider-guides/connectWise.mdx
+++ b/src/provider-guides/connectWise.mdx
@@ -18,6 +18,9 @@ export const rows = [
     label: "activities", read: true, write: true, subscribe: true,
     href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/Activities"
   }, {
+    label: "agreements", read: true, write: false, subscribe: false,
+    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/Agreements",
+  }, {
     label: "attachments", read: true, write: false, subscribe: false,
     href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/WorkflowAttachments",
   }, {

--- a/src/provider-guides/connectWise.mdx
+++ b/src/provider-guides/connectWise.mdx
@@ -18,9 +18,6 @@ export const rows = [
     label: "activities", read: true, write: true, subscribe: true,
     href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/Activities"
   }, {
-    label: "activities", read: true, write: true, subscribe: true,
-    href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/Activities"
-  }, {
     label: "attachments", read: true, write: false, subscribe: false,
     href: "https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/WorkflowAttachments",
   }, {


### PR DESCRIPTION
## Description

* Reworked the table to use a slimmer, data-driven structure.
* `Read`, `Write`, and `Subscribe` now support either a boolean value or a custom HTML node. Boolean values render as `Check`/`Cross`, while custom content is rendered directly.
* Added `href` to each object to make the ConnectWise OpenAPI file subsections easier to navigate and reduce ambiguity around similarly named endpoints.
* Marked the objects that **support subscriptions**. A few missing entries were added to the table.

For reference, the subscription-capable objects supported by our `connectors` library are listed below as a mapping:

<img width="897" height="624" alt="image" src="https://github.com/user-attachments/assets/ec15fa41-0d26-4bae-abb8-361609a61af4" />

These correspond to the ConnectWise subscription names found in the documentation:

<img width="1094" height="1040" alt="image" src="https://github.com/user-attachments/assets/514b0fd9-3921-4717-bac4-a0b3de86d73a" />

### Notes
> ConnectWise exposes two ticket-related objects, but only `project/tickets` is used for subscription support. It maps to the universal `"ticket"` value used when creating webhooks.

## Screenshot

<img width="730" height="1247" alt="image" src="https://github.com/user-attachments/assets/fafe4ad2-e33d-4c63-80dd-b8745da0eb34" />

<img width="765" height="1009" alt="image" src="https://github.com/user-attachments/assets/736e98e9-46a8-4106-8cfa-7a7745b44966" />
