### PR TITLE
[ENG-4112] docs: update notification docs

### DIFF
--- a/src/notifications/notification-payloads.mdx
+++ b/src/notifications/notification-payloads.mdx
@@ -413,8 +413,8 @@ Note: For partial failures, `success` is `false` with both `successfulRecordIds`
 
 </Accordion>
 
-<Accordion title="Connection events (created, refreshed, deleted)">
-`connection.created`, `connection.refreshed`, and `connection.deleted` share the same payload shape. `notificationType` reflects the specific event.
+<Accordion title="Connection events (created, refreshed, updated, deleted)">
+`connection.created`, `connection.refreshed`, `connection.updated`, and `connection.deleted` share the same payload shape. `notificationType` reflects the specific event.
 
 **Webhook destination payload:**
 ```json

--- a/src/notifications/overview.mdx
+++ b/src/notifications/overview.mdx
@@ -35,12 +35,13 @@ Ampersand supports the following notification event types:
 
 **Connection**
 - **`connection.created`**: Fires when a new OAuth connection is established with a SaaS provider
-- **`connection.refreshed`**: Fires when a connection's OAuth access token is refreshed
-- **`connection.deleted`**: Fires when a connection is deleted
+- **`connection.refreshed`**: Fires when Ampersand automatically refreshes a connection's OAuth access token as it nears expiry, using the connection's refresh token. This happens with no user involvement and keeps the connection active
+- **`connection.updated`**: Fires when an existing connection is updated, either when a user re-authenticates (for example, reconnecting to resolve an errored connection) or when the connection's credentials or metadata are changed via the update connection API
+- **`connection.deleted`**: Fires when a connection is deleted, such as through the dashboard or the delete connection API
 - **`connection.error`**: Fires when there's an error with an OAuth connection, such as authentication failures or token refresh issues
 
 **Destination**
-- **`destination.webhook.disabled`**: Fires when a webhook destination endpoint is disabled
+- **`destination.webhook.disabled`**: Fires when a webhook destination endpoint is disabled. This can happen automatically after repeated failed delivery attempts.
 
 ## Setting up notifications
 


### PR DESCRIPTION
## Description

Update notification docs with new `connection.updated` notification. Updates descriptions of some notifications to be more clear on how they are triggered. (for example, making clear the difference between `connection.refreshed` and `connection.updated`)

## Screenshot

Please include a screenshot of the documentation running locally with `cd src && mint dev`.  
![Screenshot 2026-07-07 at 2.12.41 PM.png](https://app.graphite.com/user-attachments/assets/174d2b8b-77fe-4ab8-9e61-4176eb6a0519.png)

![Screenshot 2026-07-07 at 2.12.55 PM.png](https://app.graphite.com/user-attachments/assets/4a017c3c-2f38-43c2-a7cf-2cd1a246dda1.png)

