### PR TITLE
fix(ci): skip commit when API ref generation produces no changes

### DIFF
--- a/.github/workflows/gen-ref-pages.yml
+++ b/.github/workflows/gen-ref-pages.yml
@@ -52,7 +52,7 @@ jobs:
           git config --global user.email "devops@withampersand.com"
           git config --global user.name "Ampersand Ops"
           git add src/
-          git commit -m "[ampersand-ops] auto: update documentation with latest api reference"
+          git diff --cached --quiet || git commit -m "[ampersand-ops] auto: update documentation with latest api reference"
           git remote set-url origin https://x-access-token:${{ secrets.AMPERSAND_OPS_PAT }}@github.com/${{ github.repository }}
           git push origin HEAD:main
         env:


### PR DESCRIPTION
## Problem

The `gen-ref-pages` workflow was failing on its **Push changes** step (e.g. [run 29853466481](https://github.com/amp-labs/docs/actions/runs/29853466481)).

The step ran `git commit` unconditionally after `git add src/`. When `pnpm run generate` produced no changes under `src/` (the API reference was already up to date), nothing was staged, so `git commit` exited with code 1 — and because the step shell runs under `set -e`, the whole job failed.

```
git add src/
git commit -m "..."
→ no changes added to commit
##[error]Process completed with exit code 1.
```

## Fix

Guard the commit so an empty staged diff is a clean no-op:

```yaml
git add src/
git diff --cached --quiet || git commit -m "..."
```

When there are generated changes, it commits and pushes as before. When there aren't, the commit is skipped and the subsequent `git push` just reports "Everything up-to-date".

🤖 Generated with [Claude Code](https://claude.com/claude-code)