### PR TITLE
feat(seo): add SEO/AEO metadata (seo block + page descriptions). 5 page descriptions.

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -14,6 +14,16 @@
       "view"
     ]
   },
+  "seo": {
+    "metatags": {
+      "og:site_name": "Ampersand Docs"
+    },
+    "indexing": "navigable",
+    "organization": {
+      "name": "Ampersand",
+      "url": "https://withampersand.com"
+    }
+  },
   "navigation": {
     "tabs": [
       {

--- a/src/generate-docs.ts
+++ b/src/generate-docs.ts
@@ -28,6 +28,15 @@ export interface DocsConfig {
   contextual?: {
     options: Array<string>;
   };
+  seo?: {
+    metatags?: Record<string, string>;
+    indexing?: string;
+    organization?: {
+      name?: string;
+      url?: string;
+      logo?: string;
+    };
+  };
   navigation: {
     tabs: Array<{
       tab: string;
@@ -114,6 +123,16 @@ export function generateDocsConfig(mintConfig: any): DocsConfig {
     favicon: mintConfig.favicon,
     contextual: {
       options: ['copy', 'view']
+    },
+    seo: {
+      metatags: {
+        'og:site_name': 'Ampersand Docs'
+      },
+      indexing: 'navigable',
+      organization: {
+        name: 'Ampersand',
+        url: 'https://withampersand.com'
+      }
     },
     navigation: {
       tabs: [

--- a/src/overview.mdx
+++ b/src/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Overview"
+description: "Ampersand is a declarative platform for SaaS builders to read, write, and subscribe to data in your customers' SaaS apps without building per-provider integrations."
 ---
 
 [Ampersand](https://www.withampersand.com/) is a declarative platform for SaaS builders who are creating product integrations. It allows you to:

--- a/src/overview.mdx
+++ b/src/overview.mdx
@@ -3,7 +3,13 @@ title: "Overview"
 description: "Ampersand is a declarative platform for reading, writing, and subscribing to data in your customers' SaaS apps. Define your integrations once and skip the per-provider code."
 ---
 
-[Ampersand](https://www.withampersand.com/) manages the full lifecycle of your product integrations, including auth, scheduled and on-demand syncs, retries, and error handling, so you can focus on your product. Here's an overview of the platform:
+[Ampersand](https://www.withampersand.com/) is a declarative platform for building product integrations without per-provider code. With a single integration, you can:
+
+* Read data from your customer's SaaS
+* Write data to your customer's SaaS
+* Subscribe to events (creates, deletes, and field changes) in your customer's SaaS
+
+Ampersand manages the full lifecycle for you, including auth, scheduled and on-demand syncs, retries, and error handling, so you can focus on your product. Here's an overview of the platform:
 
 <Frame caption="The Ampersand platform">![The Ampersand platform](/images/overview.png)</Frame>
 

--- a/src/overview.mdx
+++ b/src/overview.mdx
@@ -3,7 +3,7 @@ title: "Overview"
 description: "Ampersand is a declarative platform for reading, writing, and subscribing to data in your customers' SaaS apps. Define your integrations once and skip the per-provider code."
 ---
 
-[Ampersand](https://www.withampersand.com/) is a declarative platform for building product integrations without per-provider code. With a single integration, you can:
+With a single [Ampersand](https://www.withampersand.com/) integration, you can:
 
 * Read data from your customer's SaaS
 * Write data to your customer's SaaS

--- a/src/overview.mdx
+++ b/src/overview.mdx
@@ -3,7 +3,7 @@ title: "Overview"
 description: "Ampersand is a declarative platform for reading, writing, and subscribing to data in your customers' SaaS apps. Define your integrations once and skip the per-provider code."
 ---
 
-A single [Ampersand](https://www.withampersand.com/) integration gives you three capabilities:
+A single [Ampersand](https://www.withampersand.com/) integration gives the following capabilities:
 
 | Action | What it does |
 | --- | --- |

--- a/src/overview.mdx
+++ b/src/overview.mdx
@@ -3,11 +3,13 @@ title: "Overview"
 description: "Ampersand is a declarative platform for reading, writing, and subscribing to data in your customers' SaaS apps. Define your integrations once and skip the per-provider code."
 ---
 
-With a single [Ampersand](https://www.withampersand.com/) integration, you can:
+A single [Ampersand](https://www.withampersand.com/) integration gives you three capabilities:
 
-* Read data from your customer's SaaS
-* Write data to your customer's SaaS
-* Subscribe to events (creates, deletes, and field changes) in your customer's SaaS
+| Action | What it does |
+| --- | --- |
+| **Read** | Pull data from your customer's SaaS |
+| **Write** | Push data to your customer's SaaS |
+| **Subscribe** | Receive events (creates, deletes, and field changes) from your customer's SaaS |
 
 Ampersand manages the full lifecycle for you, including auth, scheduled and on-demand syncs, retries, and error handling, so you can focus on your product. Here's an overview of the platform:
 

--- a/src/overview.mdx
+++ b/src/overview.mdx
@@ -1,15 +1,9 @@
 ---
 title: "Overview"
-description: "Ampersand is a declarative platform for SaaS builders to read, write, and subscribe to data in your customers' SaaS apps without building per-provider integrations."
+description: "Ampersand is a declarative platform for reading, writing, and subscribing to data in your customers' SaaS apps. Define your integrations once and skip the per-provider code."
 ---
 
-[Ampersand](https://www.withampersand.com/) is a declarative platform for SaaS builders who are creating product integrations. It allows you to:
-
-* Read data from your customer's SaaS
-* Write data to your customer's SaaS
-* Subscribe to events (creates, deletes, and field changes) in your customer's SaaS. 
-
-Here's an overview of the Ampersand platform:
+[Ampersand](https://www.withampersand.com/) manages the full lifecycle of your product integrations, including auth, scheduled and on-demand syncs, retries, and error handling, so you can focus on your product. Here's an overview of the platform:
 
 <Frame caption="The Ampersand platform">![The Ampersand platform](/images/overview.png)</Frame>
 

--- a/src/quickstart.mdx
+++ b/src/quickstart.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Quickstart"
+description: "Build your first SaaS integration with Ampersand in minutes — create a project, define an amp.yaml manifest, and read and write customer data through a unified API."
 ---
 
 For this Quickstart, we are going to build integrations for a cool new app called MailMonkey - an AI-powered email campaign manager that integrates with Salesforce. You can see the final `amp.yaml` file on [Github](https://github.com/amp-labs/samples/blob/main/quickstart/amp.yaml).

--- a/src/quickstart.mdx
+++ b/src/quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Quickstart"
-description: "Build your first SaaS integration with Ampersand in minutes — create a project, define an amp.yaml manifest, and read and write customer data through a unified API."
+description: "Build your first SaaS integration with Ampersand in minutes: create a project, define an amp.yaml manifest, and read and write customer data through a unified API."
 ---
 
 For this Quickstart, we are going to build integrations for a cool new app called MailMonkey - an AI-powered email campaign manager that integrates with Salesforce. You can see the final `amp.yaml` file on [Github](https://github.com/amp-labs/samples/blob/main/quickstart/amp.yaml).

--- a/src/quickstart.mdx
+++ b/src/quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Quickstart"
-description: "Build your first SaaS integration with Ampersand in minutes: create a project, define an amp.yaml manifest, and read and write customer data through a unified API."
+description: "Build your first SaaS integration with Ampersand in minutes. Create a project, define an amp.yaml manifest, and read and write customer data through a unified API."
 ---
 
 For this Quickstart, we are going to build integrations for a cool new app called MailMonkey - an AI-powered email campaign manager that integrates with Salesforce. You can see the final `amp.yaml` file on [Github](https://github.com/amp-labs/samples/blob/main/quickstart/amp.yaml).

--- a/src/read-actions.mdx
+++ b/src/read-actions.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Read actions"
-description: "Read data from any SaaS API into your product with Ampersand read actions: scheduled or on-demand reads, historical backfill, incremental reads, and filters."
+description: "Read data from your customers' SaaS on a schedule or on demand, with backfill, incremental reads, and filters."
 ---
 
-A read action reads data from your customer's SaaS and send them to Destinations that you define.
+Data read from your customer's SaaS is delivered to the [Destinations](/destinations) you define.
 
 ## Define reads
 

--- a/src/read-actions.mdx
+++ b/src/read-actions.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Read actions"
+description: "Sync data from any SaaS API into your product with Ampersand read actions — scheduled or on-demand reads, historical backfill, incremental reads, and filters."
 ---
 
 A read action reads data from your customer's SaaS and send them to Destinations that you define.

--- a/src/read-actions.mdx
+++ b/src/read-actions.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Read actions"
-description: "Sync data from any SaaS API into your product with Ampersand read actions — scheduled or on-demand reads, historical backfill, incremental reads, and filters."
+description: "Read data from any SaaS API into your product with Ampersand read actions: scheduled or on-demand reads, historical backfill, incremental reads, and filters."
 ---
 
 A read action reads data from your customer's SaaS and send them to Destinations that you define.

--- a/src/subscribe-actions.mdx
+++ b/src/subscribe-actions.mdx
@@ -3,7 +3,7 @@ title: "Subscribe actions"
 description: "Get near-instant webhooks when records are created, updated, or deleted in your customers' SaaS apps."
 ---
 
-Subscribe actions let your app react in real time: instead of polling on a schedule, Ampersand pushes an event to your destination as soon as it happens in your customer's SaaS.
+Subscribe actions let your app react in real time: instead of polling on a schedule, Ampersand pushes an event to your [destination](/destinations) as soon as it happens in your customer's SaaS.
 
 <Note>
   Please note that:

--- a/src/subscribe-actions.mdx
+++ b/src/subscribe-actions.mdx
@@ -3,7 +3,7 @@ title: "Subscribe actions"
 description: "Get near-instant webhooks when records are created, updated, or deleted in your customers' SaaS apps."
 ---
 
-Subscribe actions let your app react in real time: instead of polling on a schedule, Ampersand pushes an event to your [destination](/destinations) as soon as it happens in your customer's SaaS.
+Subscribe actions let your app react in real time: instead of polling on a schedule, Ampersand pushes an event to your [destination](/destinations) as soon as it happens in your customer's SaaS. These capabilities enable your application to quickly react to events such as record creation, deletion, and field updates.
 
 <Note>
   Please note that:

--- a/src/subscribe-actions.mdx
+++ b/src/subscribe-actions.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Subscribe actions"
-description: "Receive near-instant webhooks when records are created, updated, or deleted in your customers' SaaS apps with Ampersand subscribe actions."
+description: "Get near-instant webhooks when records are created, updated, or deleted in your customers' SaaS apps."
 ---
 
-With subscribe actions, you'll receive near-instant webhooks as events occur in your customers' SaaS applications. This enables your application to quickly react to events such as record creation, deletion, and field updates.
+Subscribe actions let your app react in real time: instead of polling on a schedule, Ampersand pushes an event to your destination as soon as it happens in your customer's SaaS.
 
 <Note>
   Please note that:

--- a/src/subscribe-actions.mdx
+++ b/src/subscribe-actions.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Subscribe actions"
+description: "Receive near-instant webhooks when records are created, updated, or deleted in your customers' SaaS apps with Ampersand subscribe actions."
 ---
 
 With subscribe actions, you'll receive near-instant webhooks as events occur in your customers' SaaS applications. This enables your application to quickly react to events such as record creation, deletion, and field updates.

--- a/src/write-actions.mdx
+++ b/src/write-actions.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Write actions"
+description: "Write data to your customers' SaaS apps with Ampersand write actions — create and update standard and custom objects, including bulk writes, through one API."
 ---
 
 A write action writes data to your customer's SaaS whenever you make an API request to us. This page focuses on writing data to existing fields. If you are looking to create new custom fields prior to writing data, please see [Create or update custom fields](/manage-customer-schemas#create-or-update-custom-fields).

--- a/src/write-actions.mdx
+++ b/src/write-actions.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Write actions"
-description: "Write data to your customers' SaaS apps with Ampersand write actions: create and update standard and custom objects, including bulk writes, through one API."
+description: "Write data to your customers' SaaS on demand. Create and update standard and custom objects, including bulk writes."
 ---
 
-A write action writes data to your customer's SaaS whenever you make an API request to us. This page focuses on writing data to existing fields. If you are looking to create new custom fields prior to writing data, please see [Create or update custom fields](/manage-customer-schemas#create-or-update-custom-fields).
+Write actions run on demand: Ampersand writes to your customer's SaaS whenever you make an API request. This page focuses on writing to existing fields. To create custom fields first, see [Create or update custom fields](/manage-customer-schemas#create-or-update-custom-fields).
 
 ## Defining writes
 

--- a/src/write-actions.mdx
+++ b/src/write-actions.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Write actions"
-description: "Write data to your customers' SaaS apps with Ampersand write actions — create and update standard and custom objects, including bulk writes, through one API."
+description: "Write data to your customers' SaaS apps with Ampersand write actions: create and update standard and custom objects, including bulk writes, through one API."
 ---
 
 A write action writes data to your customer's SaaS whenever you make an API request to us. This page focuses on writing data to existing fields. If you are looking to create new custom fields prior to writing data, please see [Create or update custom fields](/manage-customer-schemas#create-or-update-custom-fields).


### PR DESCRIPTION
## Description

Added descriptions and re-wrote intro paragraphs for 5 core pages. Descriptions double as first paragraph/subtitle under the Title and a summary of the page for LLMs/SEO to capture. They also show as previews in links. 

<img width="473" height="350" alt="Screenshot 2026-07-21 at 5 11 25 PM" src="https://github.com/user-attachments/assets/92d30925-9802-49a3-a02e-6780118a5b48" />


### SEO Changes

First increment of an SEO/AEO discoverability pass ("quick wins"). Two self-contained, additive changes:

**1. `seo` block in `docs.json`** (added via `generate-docs.ts` so it survives regeneration):
- `og:site_name` — social card metadata
- `indexing: "navigable"` — index pages in the nav (safe default, matches current behavior)
- `organization` — publisher structured data → better Google / AI-engine entity understanding

**2. `description` frontmatter** on 5 flagship pages (`overview`, `quickstart`, `read-actions`, `write-actions`, `subscribe-actions`).

Why it matters: **326 of 327 pages currently have no `description`.** In Mintlify, `description` feeds the `<meta name="description">`, the OG/Twitter social preview, the search-result snippet, **and the auto-generated `llms.txt`/`llms-full.txt`** that AI answer engines (ChatGPT, Perplexity, Claude, Google AI Overviews) read. Each description here is answer-first, ~150 chars, leading with "Ampersand" + the primary keyword.

### Deferred (not in this PR)
- `og:image` — omitted to avoid a poor social card from the transparent logo; needs a proper 1200×630 branded image.
- Descriptions for the remaining ~15 hand-written core pages (drafts ready).
- Provider guides (191) and API-reference pages (descriptions live upstream in `amp-labs/openapi`).

### Notes for review
- `src/generate-docs.ts` is the source of truth; `src/docs.json` is the regenerated output (committed because Mintlify consumes it). The `docs.json` diff is 10 lines, additive only — no navigation churn.
- If hidden/unlisted pages should rank, switch `indexing` to `"all"`.

