### PR TITLE
docs(attio): add Subscribe Actions support

### DIFF
--- a/src/provider-guides/attio.mdx
+++ b/src/provider-guides/attio.mdx
@@ -22,7 +22,7 @@ export const rows = [
   { label: "Deals", href: "https://docs.attio.com/rest-api/endpoint-reference/standard-objects/deals/assert-a-deal-record", read: true, write: true, subscribe: true },
   { label: "Workspaces", href: "https://docs.attio.com/rest-api/endpoint-reference/standard-objects/workspaces/assert-a-workspace-record", read: true, write: true, subscribe: true },
   { label: "Lists", href: "https://docs.attio.com/rest-api/endpoint-reference/lists/list-all-lists", read: true, write: true, subscribe: true },
-  { label: "WorkspaceMembers", href: "https://docs.attio.com/rest-api/endpoint-reference/workspace-members/list-workspace-members", read: true, write: true, subscribe: true },
+  { label: "WorkspaceMembers", href: "https://docs.attio.com/rest-api/endpoint-reference/workspace-members/list-workspace-members", read: true, write: true, subscribe: "create only" },
   { label: "Notes", href: "https://docs.attio.com/rest-api/endpoint-reference/notes/list-notes", read: true, write: true, subscribe: true },
   { label: "Tasks", href: "https://docs.attio.com/rest-api/endpoint-reference/tasks/list-tasks", read: true, write: true, subscribe: true },
   { label: "Custom objects", href: "https://docs.attio.com/rest-api/endpoint-reference/records/list-records", read: true, write: true, subscribe: true },
@@ -30,6 +30,7 @@ export const rows = [
 
 export const Check = () => <span>✅</span>
 export const Cross = () => <span>🚫</span>
+export const Partial = ({ label }) => <span title={label}>✅*</span>
 
 <div style={{width: '100%', overflowX: 'auto', display: 'block'}}>
   <table style={{
@@ -50,16 +51,18 @@ export const Cross = () => <span>🚫</span>
     </thead>
     <tbody style={{display: 'table-row-group', width: '100%'}}>
     {rows.map((row) => (
-      <tr id={"row/" + row.label} key={row.label}>
+      <tr id={("row/" + row.label).replace(/\s+/g, '-').toLowerCase()} key={row.label}>
         <td style={{textAlign: "left"}}><a href={row.href}>{row.label}</a></td>
         <td>{row.read ? <Check/> : <Cross/>}</td>
         <td>{row.write ? <Check/> : <Cross/>}</td>
-        <td>{row.subscribe ? <Check/> : <Cross/>}</td>
+        <td>{row.subscribe === true ? <Check/> : row.subscribe ? <Partial label={row.subscribe}/> : <Cross/>}</td>
       </tr>
     ))}
     </tbody>
   </table>
 </div>
+
+\* WorkspaceMembers only supports **create** events for subscriptions.
 
 ### Subscribe events
 

--- a/src/provider-guides/attio.mdx
+++ b/src/provider-guides/attio.mdx
@@ -8,33 +8,92 @@ title: "Attio"
 This connector supports:
 - [Read Actions](/read-actions), including full historic backfill and incremental read.
 - [Write Actions](/write-actions).
+- [Subscribe Actions](/subscribe-actions). Ampersand creates and manages the Attio webhook subscription on your behalf when the customer installs your integration — no manual webhook setup is required in the Attio UI.
 - [Proxy Actions](/proxy-actions), using the base URL `https://api.attio.com`.
 
 ### Supported Objects
-The Attio connector supports reading to the following objects:
 
-- [People](https://docs.attio.com/rest-api/endpoint-reference/standard-objects/people/list-person-records)
-- [Companies](https://docs.attio.com/rest-api/endpoint-reference/standard-objects/companies/list-company-records)
-- [Users](https://docs.attio.com/rest-api/endpoint-reference/standard-objects/users/list-user-records)
-- [Deals](https://docs.attio.com/rest-api/endpoint-reference/standard-objects/deals/assert-a-deal-record)
-- [Workspaces](https://docs.attio.com/rest-api/endpoint-reference/standard-objects/workspaces/assert-a-workspace-record)
-- [Lists](https://docs.attio.com/rest-api/endpoint-reference/lists/list-all-lists)
-- [WorkspaceMembers](https://docs.attio.com/rest-api/endpoint-reference/workspace-members/list-workspace-members)
-- [Notes](https://docs.attio.com/rest-api/endpoint-reference/notes/list-notes)
-- [Tasks](https://docs.attio.com/rest-api/endpoint-reference/tasks/list-tasks)
-- [Custom objects](https://docs.attio.com/rest-api/endpoint-reference/records/list-records)
+The Attio connector supports the following objects:
 
-The Attio connector supports writing to the following objects:
-- [People](https://docs.attio.com/rest-api/endpoint-reference/standard-objects/people/list-person-records)
-- [Companies](https://docs.attio.com/rest-api/endpoint-reference/standard-objects/companies/list-company-records)
-- [Users](https://docs.attio.com/rest-api/endpoint-reference/standard-objects/users/list-user-records)
-- [Deals](https://docs.attio.com/rest-api/endpoint-reference/standard-objects/deals/assert-a-deal-record)
-- [Workspaces](https://docs.attio.com/rest-api/endpoint-reference/standard-objects/workspaces/assert-a-workspace-record)
-- [Lists](https://docs.attio.com/rest-api/endpoint-reference/lists/list-all-lists)
-- [WorkspaceMembers](https://docs.attio.com/rest-api/endpoint-reference/workspace-members/list-workspace-members)
-- [Notes](https://docs.attio.com/rest-api/endpoint-reference/notes/list-notes)
-- [Tasks](https://docs.attio.com/rest-api/endpoint-reference/tasks/list-tasks)
-- [Custom objects](https://docs.attio.com/rest-api/endpoint-reference/records/list-records)
+export const rows = [
+  { label: "People", href: "https://docs.attio.com/rest-api/endpoint-reference/standard-objects/people/list-person-records", read: true, write: true, subscribe: true },
+  { label: "Companies", href: "https://docs.attio.com/rest-api/endpoint-reference/standard-objects/companies/list-company-records", read: true, write: true, subscribe: true },
+  { label: "Users", href: "https://docs.attio.com/rest-api/endpoint-reference/standard-objects/users/list-user-records", read: true, write: true, subscribe: true },
+  { label: "Deals", href: "https://docs.attio.com/rest-api/endpoint-reference/standard-objects/deals/assert-a-deal-record", read: true, write: true, subscribe: true },
+  { label: "Workspaces", href: "https://docs.attio.com/rest-api/endpoint-reference/standard-objects/workspaces/assert-a-workspace-record", read: true, write: true, subscribe: true },
+  { label: "Lists", href: "https://docs.attio.com/rest-api/endpoint-reference/lists/list-all-lists", read: true, write: true, subscribe: true },
+  { label: "WorkspaceMembers", href: "https://docs.attio.com/rest-api/endpoint-reference/workspace-members/list-workspace-members", read: true, write: true, subscribe: true },
+  { label: "Notes", href: "https://docs.attio.com/rest-api/endpoint-reference/notes/list-notes", read: true, write: true, subscribe: true },
+  { label: "Tasks", href: "https://docs.attio.com/rest-api/endpoint-reference/tasks/list-tasks", read: true, write: true, subscribe: true },
+  { label: "Custom objects", href: "https://docs.attio.com/rest-api/endpoint-reference/records/list-records", read: true, write: true, subscribe: true },
+]
+
+export const Check = () => <span>✅</span>
+export const Cross = () => <span>🚫</span>
+
+<div style={{width: '100%', overflowX: 'auto', display: 'block'}}>
+  <table style={{
+    width: '100%',
+    minWidth: '100%',
+    tableLayout: 'fixed',
+    textAlign: 'center',
+    borderCollapse: 'collapse',
+    display: 'table'
+  }}>
+    <thead style={{display: 'table-header-group', width: '100%'}}>
+    <tr style={{display: 'table-row', width: '100%'}}>
+      <th style={{textAlign: 'left', width: '40%'}}>Object</th>
+      <th style={{width: '20%'}}>Read</th>
+      <th style={{width: '20%'}}>Write</th>
+      <th style={{width: '20%'}}>Subscribe</th>
+    </tr>
+    </thead>
+    <tbody style={{display: 'table-row-group', width: '100%'}}>
+    {rows.map((row) => (
+      <tr id={"row/" + row.label} key={row.label}>
+        <td style={{textAlign: "left"}}><a href={row.href}>{row.label}</a></td>
+        <td>{row.read ? <Check/> : <Cross/>}</td>
+        <td>{row.write ? <Check/> : <Cross/>}</td>
+        <td>{row.subscribe ? <Check/> : <Cross/>}</td>
+      </tr>
+    ))}
+    </tbody>
+  </table>
+</div>
+
+### Subscribe events
+
+Attio uses two subscription patterns depending on the object:
+
+- **Standard and custom objects** (People, Companies, Users, Deals, Workspaces, and any custom object) are subscribed through Attio's generic record events (`record.created`, `record.updated`, `record.deleted`), scoped to the specific object. They support **create**, **update**, and **delete** events.
+- **Core objects** are subscribed through object-specific events: **Notes**, **Tasks**, and **Lists** support **create**, **update**, and **delete**; **WorkspaceMembers** supports **create** only.
+
+Please note that:
+
+- **Watched fields are not supported.** Attio webhook payloads do not include changed-field data, so field-level update filtering (`requiredWatchFields`) is not available. Use `watchFieldsAuto: all` for update events — they fire on any change to the record, and Ampersand fetches the full updated record for you.
+- **Scopes gate webhook creation and delivery.** Your Attio app must be granted **read-write access to the Webhooks scope** (to create the subscription) and **read access to record objects** (so Ampersand can fetch the changed record). Grant these under **Workspace settings → Developers → [your app] → Scopes**; without them, subscription creation fails with a `403`.
+
+For example:
+
+```yaml
+subscribe:
+  objects:
+    - objectName: people
+      destination: attioWebhook
+      inheritFieldsAndMapping: true
+      createEvent:
+        enabled: always
+      updateEvent:
+        enabled: always
+        watchFieldsAuto: all
+      deleteEvent:
+        enabled: always
+    - objectName: notes
+      destination: attioWebhook
+      inheritFieldsAndMapping: true
+      createEvent:
+        enabled: always
+```
 
 ### Example integration
 
@@ -99,9 +158,9 @@ Follow the steps below to create an Attio app and add the Ampersand redirect URL
 To start integrating with Attio:
 - Create a manifest file using the [example](https://github.com/amp-labs/samples/blob/main/attio/amp.yaml).
 - Deploy it using the [amp CLI](/cli/overview).
-- If you are using Read Actions, create a [destination](/destinations).
+- If you are using Read Actions or Subscribe Actions, create a [destination](/destinations).
 - Embed the [InstallIntegration](/embeddable-ui-components#install-integration) UI component.
 - Start using the connector!
-   - If your integration has [Read Actions](/read-actions), you'll start getting webhook messages.
+   - If your integration has [Read Actions](/read-actions) or [Subscribe Actions](/subscribe-actions), you'll start getting webhook messages.
    - If your integration has [Write Actions](/write-actions), you can start making API calls to our Write API.
    - If your integration has [Proxy Actions](/proxy-actions), you can start making Proxy API calls.

--- a/src/provider-guides/attio.mdx
+++ b/src/provider-guides/attio.mdx
@@ -66,10 +66,11 @@ export const Cross = () => <span>🚫</span>
 Attio uses two subscription patterns depending on the object:
 
 - **Standard and custom objects** (People, Companies, Users, Deals, Workspaces, and any custom object) are subscribed through Attio's generic record events (`record.created`, `record.updated`, `record.deleted`), scoped to the specific object. They support **create**, **update**, and **delete** events.
-- **Core objects** are subscribed through object-specific events: **Notes**, **Tasks**, and **Lists** support **create**, **update**, and **delete**; **WorkspaceMembers** supports **create** only.
+- **Core objects** are subscribed through object-specific events: **Notes**, **Tasks**, and **Lists** support **create**, **update**, and **delete**; **WorkspaceMembers** supports **create** only. Note that **Lists** events fire on the list object itself (a list being created, updated, or deleted) — not on records being added to or removed from a list.
 
 Please note that:
 
+- **Standard objects must be activated.** Attio delivers `record.*` events only for objects that are active in the workspace. People, Companies, and Deals are active by default; Users and Workspaces are optional standard objects that must be enabled under **Workspace settings → Objects** before they can be subscribed to.
 - **Watched fields are not supported.** Attio webhook payloads do not include changed-field data, so field-level update filtering (`requiredWatchFields`) is not available. Use `watchFieldsAuto: all` for update events — they fire on any change to the record, and Ampersand fetches the full updated record for you.
 - **Scopes gate webhook creation and delivery.** Your Attio app must be granted **read-write access to the Webhooks scope** (to create the subscription) and **read access to record objects** (so Ampersand can fetch the changed record). Grant these under **Workspace settings → Developers → [your app] → Scopes**; without them, subscription creation fails with a `403`.
 


### PR DESCRIPTION
Documents Attio's newly-shipped **Subscribe** capability, following the existing provider pattern (modeled on Jobber, which is the closest analog — Ampersand-managed webhooks, no watched-field support).

## Changes (all in `src/provider-guides/attio.mdx`)
- **Supported Actions:** add `- [Subscribe Actions](/subscribe-actions).` with a note that Ampersand creates/manages the Attio webhook subscription automatically (no manual setup in the Attio UI).
- **Supported Objects:** convert the two plain read/write bullet lists into the standard **Read / Write / Subscribe** table (with the `Check`/`Cross` export components other providers use).
- **New "Subscribe events" section** documenting:
  - The two subscription patterns — standard/custom objects (People, Companies, Users, Deals, Workspaces, custom) via Attio's generic `record.*` events (create/update/delete); core objects via object-specific events (Notes/Tasks/Lists create/update/delete, **WorkspaceMembers create-only**).
  - `watchFieldsAuto: all` is required (Attio webhooks don't report changed fields; Ampersand fetches the full record).
  - Required scopes (Webhooks read-write + record read) — omitting them fails webhook creation with a `403`.
  - A YAML `subscribe:` example.
- **Using the connector:** reference Subscribe Actions alongside Read Actions for destinations/webhook messages.

## Source of truth
Content derived from the Attio connector implementation in `amp-labs/connectors` (supported events per object, the two-pattern routing, scope requirements) and validated end-to-end against a live Attio workspace this cycle.

No nav/registry changes needed — Attio is already in the sidebar, and the docs repo has no capability matrix (capabilities are declared per-page).


## Test

<img width="1026" height="1266" alt="Screenshot 2026-07-23 at 11 48 48 AM" src="https://github.com/user-attachments/assets/a21bbbf8-5968-483c-9928-4c5452f21d32" />
<img width="1057" height="1218" alt="Screenshot 2026-07-23 at 11 48 56 AM" src="https://github.com/user-attachments/assets/f31d8fb7-706d-4a4b-9974-d1e5a91c5ed9" />
