### PR TITLE
[Docs] Add Microsoft (Admin consent) provider guide

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -194,6 +194,7 @@
                   "provider-guides/marketo",
                   "provider-guides/meta",
                   "provider-guides/microsoft",
+                  "provider-guides/microsoftAdminConsent",
                   "provider-guides/miro",
                   "provider-guides/mixmax",
                   "provider-guides/mixpanel",

--- a/src/generate-docs.ts
+++ b/src/generate-docs.ts
@@ -426,6 +426,7 @@ const baseConfig = {
             "provider-guides/marketo",
             "provider-guides/meta",
             "provider-guides/microsoft",
+            "provider-guides/microsoftAdminConsent",
             "provider-guides/miro",
             "provider-guides/mixmax",
             "provider-guides/mixpanel",

--- a/src/provider-guides/microsoftAdminConsent.mdx
+++ b/src/provider-guides/microsoftAdminConsent.mdx
@@ -1,0 +1,88 @@
+---
+title: "Microsoft (Admin consent)"
+slug: "microsoftAdminConsent"
+excerpt: ""
+hidden: false
+---
+The Microsoft (Admin consent) connector provides application-level access to the Microsoft Graph API. A tenant administrator grants consent once for the whole organization, so Ampersand can call Graph without any individual user signing in.
+
+Use this connector for org-wide, app-level access. For access scoped to an individual signed-in user, use the [Microsoft](/provider-guides/microsoft) connector instead.
+
+## What's Supported
+
+### Supported Actions
+
+This connector supports:
+- [Read Actions](/read-actions), including full historic backfill and incremental read.
+- [Write Actions](/write-actions).
+- [Proxy Actions](/proxy-actions), using the base URL `https://graph.microsoft.com`.
+
+### Supported Objects
+
+This connector supports **many Microsoft Graph API objects** including but not limited to:
+
+- [users](https://learn.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0)
+- [calendars](https://learn.microsoft.com/en-us/graph/api/resources/calendar?view=graph-rest-1.0)
+- [events](https://learn.microsoft.com/en-us/graph/api/resources/event?view=graph-rest-1.0)
+- [messages](https://learn.microsoft.com/en-us/graph/api/resources/message?view=graph-rest-1.0)
+
+For the complete list, refer to the [Microsoft Graph API documentation](https://learn.microsoft.com/en-us/graph/api/overview?view=graph-rest-1.0). To find the exact **Application** permission each object requires, you can use a tool such as the [Graph Permissions Explorer](https://graphpermissions.merill.net/permission/).
+
+## Before You Get Started
+
+To connect Microsoft services with Ampersand, you will need [a Microsoft Account](https://aka.ms/AppRegistrations).
+
+Once your account is created, you'll need to create an app in the Azure portal, configure the Ampersand redirect URI within the app, and obtain the following credentials from your app:
+
+- Client ID
+- Client Secret
+
+You will then use these credentials to connect your application to Ampersand.
+
+### Creating a Microsoft App
+
+Follow the steps below to create a Microsoft app and add the Ampersand redirect URL.
+
+1. Log in to your [Azure Portal](https://portal.azure.com/).
+
+2. Navigate to **Microsoft Entra ID** (Azure Active Directory) > **App registrations**.
+
+3. Click the **New registration** button.
+
+4. In the **Register an application** window, enter the **Name** and select the **Supported account types**, then click **Register**.
+
+5. In the left-hand sidebar, navigate to **Manage > Authentication** > **Add a platform** > **Web**, and enter the Ampersand redirect URL: `https://api.withampersand.com/callbacks/v1/custom-auth/default`.
+
+6. In the left-hand sidebar, navigate to **Certificates & secrets** > **New client secret**, provide a description and expiration period, and click **Add**. Note the Client Secret value. You will need it later.
+
+7. In the left-hand sidebar, navigate to **Manage > API permissions** > **Add a permission** > **Microsoft Graph** > **Application permissions**, and choose the permissions your integration requires.
+
+<Warning>You must add **Application permissions**, not **Delegated permissions**. Application-level access via admin consent uses application permissions; delegated permissions will not work with this connector.</Warning>
+
+## Add Your Microsoft App Info to Ampersand
+
+1. Log in to your [Ampersand Dashboard](https://dashboard.withampersand.com).
+
+2. Select the project where you want to create a Microsoft integration.
+
+3. Select **Provider Apps**.
+
+4. Select **Microsoft (Admin consent)** from the **Provider** list.
+
+5. Enter the previously generated Client Secret in the **Client Secret** field.
+
+6. For the **Client ID** field, go to the Overview page in your Microsoft application, and copy the **Application ID**.
+
+7. Click **Save Changes**.
+
+## Using the connector
+
+To start integrating with Microsoft:
+- Create a manifest file like the [example](https://github.com/amp-labs/samples/blob/main/microsoft/amp.yaml), using `microsoftAdminConsent` as the provider.
+- Deploy it using the [amp CLI](/cli/overview).
+- If you are using Read Actions, create a [destination](/destinations).
+- Embed the [InstallIntegration](/embeddable-ui-components#install-integration) UI component.
+- Start using the connector!
+   - If your integration has [Read Actions](/read-actions), you'll start getting webhook messages.
+   - If your integration has [Write Actions](/write-actions), you can start making API calls to our Write API.
+   - If your integration has [Proxy Actions](/proxy-actions), you can start making Proxy API calls.

--- a/src/provider-guides/microsoftAdminConsent.mdx
+++ b/src/provider-guides/microsoftAdminConsent.mdx
@@ -78,7 +78,7 @@ Follow the steps below to create a Microsoft app and add the Ampersand redirect 
 ## Using the connector
 
 To start integrating with Microsoft:
-- Create a manifest file like the [example](https://github.com/amp-labs/samples/blob/main/microsoft/amp.yaml), using `microsoftAdminConsent` as the provider.
+- Create a manifest file like the [example](https://github.com/amp-labs/samples/blob/main/microsoftAdminConsent/amp.yaml).
 - Deploy it using the [amp CLI](/cli/overview).
 - If you are using Read Actions, create a [destination](/destinations).
 - Embed the [InstallIntegration](/embeddable-ui-components#install-integration) UI component.

--- a/src/provider-guides/microsoftAdminConsent.mdx
+++ b/src/provider-guides/microsoftAdminConsent.mdx
@@ -4,7 +4,7 @@ slug: "microsoftAdminConsent"
 excerpt: ""
 hidden: false
 ---
-The Microsoft (Admin consent) connector provides application-level access to the Microsoft Graph API. A tenant administrator grants consent once for the whole organization, so Ampersand can call Graph without any individual user signing in.
+The Microsoft (Admin consent) connector provides application-level access to the Microsoft Graph API. A tenant administrator grants consent once for the whole organization, so Ampersand can call Graph without any individual user signing in. Depending on your tenant's setup, granting consent for application permissions may require an administrator with elevated privileges (such as a Global Administrator).
 
 Use this connector for org-wide, app-level access. For access scoped to an individual signed-in user, use the [Microsoft](/provider-guides/microsoft) connector instead.
 
@@ -49,7 +49,7 @@ Follow the steps below to create a Microsoft app and add the Ampersand redirect 
 
 3. Click the **New registration** button.
 
-4. In the **Register an application** window, enter the **Name** and select the **Supported account types**, then click **Register**.
+4. In the **Register an application** window, enter the **Name** and select the **Supported account types** that fit your scenario — if your customers will connect from their own Microsoft tenants, choose an option that includes multiple organizations. Then click **Register**.
 
 5. In the left-hand sidebar, navigate to **Manage > Authentication** > **Add a platform** > **Web**, and enter the Ampersand redirect URL: `https://api.withampersand.com/callbacks/v1/custom-auth/default`.
 


### PR DESCRIPTION
Adds a provider guide for the Microsoft (Admin consent) connector — app-only Microsoft Graph access via admin consent.

<img width="1205" height="802" alt="image" src="https://github.com/user-attachments/assets/fe72825a-69ef-4aba-8c80-c14a09eae4b6" />