### PR TITLE
[CON-3243] feat: add google calendar subscribe guide

### DIFF
--- a/src/provider-guides/google.mdx
+++ b/src/provider-guides/google.mdx
@@ -17,6 +17,7 @@ This connector supports:
 The **Calendar** module supports:
 - [Read Actions](/read-actions), including historical backfill. Please note that incremental
 read **is only supported for the Calendar `Events` object**; otherwise, a full read of the Google instance will be performed for each scheduled run.
+- [Subscribe Actions](/subscribe-actions) for the `events` object — see [Calendar Subscribe Actions](#calendar-subscribe-actions).
 - [Write Actions](/write-actions).
 
 > **Important Note on Events Backfill**: The `events` object has a 28-day cap for historic backfill and does not support full history, due to limitations in the Google API. When syncing events data, ensure your backfill period does not exceed 28 days.
@@ -37,15 +38,16 @@ export const Cross = () => <span>🚫</span>
   <thead style={{ display: 'table-header-group', width: '100%' }}>
     <tr style={{ display: 'table-row', width: '100%' }}>
       <th style={{ textAlign: 'left', width: '40%' }}>Object</th>
-      <th style={{ width: '30%' }}>Read</th>
-      <th style={{ width: '30%' }}>Write</th>
+      <th style={{ width: '20%' }}>Read</th>
+      <th style={{ width: '20%' }}>Write</th>
+      <th style={{ width: '20%' }}>Subscribe</th>
     </tr>
   </thead>
   <tbody style={{ display: 'table-row-group', width: '100%' }}>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}><a href="https://developers.google.com/workspace/calendar/api/v3/reference/acl">acl</a></td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}><a href="https://developers.google.com/calendar/api/v3/reference/calendarList#resource-representations">calendarList</a></td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}><a href="https://developers.google.com/workspace/calendar/api/v3/reference/events">events</a></td><td><Check /></td><td><Check /></td></tr>
-    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}><a href="https://developers.google.com/workspace/calendar/api/v3/reference/settings">settings</a></td><td><Check /></td><td><Cross /></td></tr>
+    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}><a href="https://developers.google.com/workspace/calendar/api/v3/reference/acl">acl</a></td><td><Check /></td><td><Check /></td><td><Cross /></td></tr>
+    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}><a href="https://developers.google.com/calendar/api/v3/reference/calendarList#resource-representations">calendarList</a></td><td><Check /></td><td><Check /></td><td><Cross /></td></tr>
+    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}><a href="https://developers.google.com/workspace/calendar/api/v3/reference/events">events</a></td><td><Check /></td><td><Check /></td><td><Check /></td></tr>
+    <tr style={{ display: 'table-row' }}><td style={{ textAlign: 'left' }}><a href="https://developers.google.com/workspace/calendar/api/v3/reference/settings">settings</a></td><td><Check /></td><td><Cross /></td><td><Cross /></td></tr>
   </tbody>
 </table>
 </div>
@@ -172,6 +174,18 @@ Follow the steps below to create a Google App:
 ![Scopes](/images/provider-guides/6b33461-Screenshot_2024-07-19_at_1.10.08_PM.png)
 
 6. Click **Save changes**.
+
+## Calendar Subscribe Actions
+
+Ampersand creates and manages the webhook subscriptions on your behalf when the customer installs your integration — no manual webhook setup is required.
+
+To receive events, you must explicitly define a `subscribe` section for the `events` object in your integration's [`amp.yaml`](https://github.com/amp-labs/samples/blob/main/google-calendar/amp.yaml) manifest, alongside a corresponding read action. See [Subscribe Actions](/subscribe-actions) for the manifest format.
+
+### Caveats
+
+- **`events` is the only supported object.** Changes to `acl`, `calendarList`, and `settings` are not delivered as Subscribe events.
+- **Primary calendar only.** Only changes on the connected user's primary calendar are delivered.
+- **No historical backfill via Subscribe.** Subscribe events start from the moment the watch channel is created. To sync existing events, combine your Subscribe action with a [Read action](/read-actions) that has `backfill` configured (note the 28-day cap on `events` backfill mentioned above).
 
 ## Set up Gmail push notifications for Subscribe Actions
 


### PR DESCRIPTION
## Description
Adds google calendar susbcribe action guides. I have updated sample [here](https://github.com/amp-labs/samples/pull/149)

## Screenshot
<img width="1464" height="881" alt="Screenshot 2026-07-28 at 11 40 50" src="https://github.com/user-attachments/assets/dc886876-4374-4008-83d7-145cb421fbea" />
<img width="1462" height="813" alt="Screenshot 2026-07-28 at 11 40 31" src="https://github.com/user-attachments/assets/cca2b3e4-83a9-4e93-b13e-d75952174745" />
<img width="1460" height="835" alt="Screenshot 2026-07-28 at 11 40 15" src="https://github.com/user-attachments/assets/d762e117-5bfc-49ce-bfb3-f04bf94882e7" />

